### PR TITLE
/relations: graphviz → d3

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1650,6 +1650,10 @@ body > div#main-content {
 .bg-yellow\/20 {
   background-color: rgb(226 209 52 / 0.2);
 }
+.bg-black {
+  --tw-bg-opacity: 1;
+  background-color: rgb(0 0 0 / var(--tw-bg-opacity));
+}
 .bg-gradient-to-b {
   background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
 }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -914,6 +914,9 @@ body > div#main-content {
 .top-\[calc\(50\%-0\.75rem\)\] {
   top: calc(50% - 0.75rem);
 }
+.top-2\.5 {
+  top: 0.625rem;
+}
 .z-10 {
   z-index: 10;
 }
@@ -922,6 +925,9 @@ body > div#main-content {
 }
 .z-50 {
   z-index: 50;
+}
+.z-20 {
+  z-index: 20;
 }
 .order-2 {
   order: 2;
@@ -1164,6 +1170,9 @@ body > div#main-content {
 .max-h-\[calc\(100vh-2rem\)\] {
   max-height: calc(100vh - 2rem);
 }
+.max-h-60 {
+  max-height: 15rem;
+}
 .min-h-36 {
   min-height: 9rem;
 }
@@ -1205,6 +1214,9 @@ body > div#main-content {
 }
 .w-screen {
   width: 100vw;
+}
+.w-64 {
+  width: 16rem;
 }
 .min-w-0 {
   min-width: 0px;
@@ -1888,6 +1900,10 @@ body > div#main-content {
 .text-white\/80 {
   color: rgb(255 255 255 / 0.8);
 }
+.text-indigo-600 {
+  --tw-text-opacity: 1;
+  color: rgb(79 70 229 / var(--tw-text-opacity));
+}
 .\!text-opacity-75 {
   --tw-text-opacity: 0.75 !important;
 }
@@ -2232,6 +2248,10 @@ body > div#main-content {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
+.hover\:text-gray-600:hover {
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity));
+}
 .hover\:\!text-opacity-100:hover {
   --tw-text-opacity: 1 !important;
 }
@@ -2243,6 +2263,14 @@ body > div#main-content {
 }
 .focus\:border-transparent:focus {
   border-color: transparent;
+}
+.focus\:border-indigo-500:focus {
+  --tw-border-opacity: 1;
+  border-color: rgb(99 102 241 / var(--tw-border-opacity));
+}
+.focus\:outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
 }
 .focus\:outline:focus {
   outline-style: solid;
@@ -2264,6 +2292,10 @@ body > div#main-content {
 .focus\:ring-blue-500:focus {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(52 156 226 / var(--tw-ring-opacity));
+}
+.focus\:ring-indigo-500:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(99 102 241 / var(--tw-ring-opacity));
 }
 .group:hover .group-hover\:text-blue {
   --tw-text-opacity: 1;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -875,8 +875,8 @@ body > div#main-content {
 .-bottom-16 {
   bottom: -4rem;
 }
-.-top-2 {
-  top: -0.5rem;
+.-top-1 {
+  top: -0.25rem;
 }
 .bottom-0 {
   bottom: 0px;
@@ -913,9 +913,6 @@ body > div#main-content {
 }
 .top-\[calc\(50\%-0\.75rem\)\] {
   top: calc(50% - 0.75rem);
-}
-.-top-1 {
-  top: -0.25rem;
 }
 .z-10 {
   z-index: 10;
@@ -986,6 +983,9 @@ body > div#main-content {
 .my-4 {
   margin-top: 1rem;
   margin-bottom: 1rem;
+}
+.\!mb-2 {
+  margin-bottom: 0.5rem !important;
 }
 .\!mt-0 {
   margin-top: 0px !important;
@@ -1058,9 +1058,6 @@ body > div#main-content {
 }
 .mt-8 {
   margin-top: 2rem;
-}
-.\!mb-2 {
-  margin-bottom: 0.5rem !important;
 }
 .block {
   display: block;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1761,6 +1761,9 @@ body > div#main-content {
 .pt-8 {
   padding-top: 2rem;
 }
+.pt-16 {
+  padding-top: 4rem;
+}
 .text-left {
   text-align: left;
 }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1173,6 +1173,12 @@ body > div#main-content {
 .max-h-60 {
   max-height: 15rem;
 }
+.max-h-full {
+  max-height: 100%;
+}
+.max-h-\[80vh\] {
+  max-height: 80vh;
+}
 .min-h-36 {
   min-height: 9rem;
 }
@@ -1439,6 +1445,9 @@ body > div#main-content {
 }
 .self-end {
   align-self: flex-end;
+}
+.overflow-auto {
+  overflow: auto;
 }
 .overflow-hidden {
   overflow: hidden;

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -1650,6 +1650,10 @@ body > div#main-content {
 .bg-yellow\/20 {
   background-color: rgb(226 209 52 / 0.2);
 }
+.bg-black {
+  --tw-bg-opacity: 1;
+  background-color: rgb(0 0 0 / var(--tw-bg-opacity));
+}
 .bg-gradient-to-b {
   background-image: linear-gradient(to bottom, var(--tw-gradient-stops));
 }

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -914,6 +914,9 @@ body > div#main-content {
 .top-\[calc\(50\%-0\.75rem\)\] {
   top: calc(50% - 0.75rem);
 }
+.top-2\.5 {
+  top: 0.625rem;
+}
 .z-10 {
   z-index: 10;
 }
@@ -922,6 +925,9 @@ body > div#main-content {
 }
 .z-50 {
   z-index: 50;
+}
+.z-20 {
+  z-index: 20;
 }
 .order-2 {
   order: 2;
@@ -1164,6 +1170,9 @@ body > div#main-content {
 .max-h-\[calc\(100vh-2rem\)\] {
   max-height: calc(100vh - 2rem);
 }
+.max-h-60 {
+  max-height: 15rem;
+}
 .min-h-36 {
   min-height: 9rem;
 }
@@ -1205,6 +1214,9 @@ body > div#main-content {
 }
 .w-screen {
   width: 100vw;
+}
+.w-64 {
+  width: 16rem;
 }
 .min-w-0 {
   min-width: 0px;
@@ -1888,6 +1900,10 @@ body > div#main-content {
 .text-white\/80 {
   color: rgb(255 255 255 / 0.8);
 }
+.text-indigo-600 {
+  --tw-text-opacity: 1;
+  color: rgb(79 70 229 / var(--tw-text-opacity));
+}
 .\!text-opacity-75 {
   --tw-text-opacity: 0.75 !important;
 }
@@ -2232,6 +2248,10 @@ body > div#main-content {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
+.hover\:text-gray-600:hover {
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity));
+}
 .hover\:\!text-opacity-100:hover {
   --tw-text-opacity: 1 !important;
 }
@@ -2243,6 +2263,14 @@ body > div#main-content {
 }
 .focus\:border-transparent:focus {
   border-color: transparent;
+}
+.focus\:border-indigo-500:focus {
+  --tw-border-opacity: 1;
+  border-color: rgb(99 102 241 / var(--tw-border-opacity));
+}
+.focus\:outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
 }
 .focus\:outline:focus {
   outline-style: solid;
@@ -2264,6 +2292,10 @@ body > div#main-content {
 .focus\:ring-blue-500:focus {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(52 156 226 / var(--tw-ring-opacity));
+}
+.focus\:ring-indigo-500:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(99 102 241 / var(--tw-ring-opacity));
 }
 .group:hover .group-hover\:text-blue {
   --tw-text-opacity: 1;

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -875,8 +875,8 @@ body > div#main-content {
 .-bottom-16 {
   bottom: -4rem;
 }
-.-top-2 {
-  top: -0.5rem;
+.-top-1 {
+  top: -0.25rem;
 }
 .bottom-0 {
   bottom: 0px;
@@ -913,9 +913,6 @@ body > div#main-content {
 }
 .top-\[calc\(50\%-0\.75rem\)\] {
   top: calc(50% - 0.75rem);
-}
-.-top-1 {
-  top: -0.25rem;
 }
 .z-10 {
   z-index: 10;
@@ -986,6 +983,9 @@ body > div#main-content {
 .my-4 {
   margin-top: 1rem;
   margin-bottom: 1rem;
+}
+.\!mb-2 {
+  margin-bottom: 0.5rem !important;
 }
 .\!mt-0 {
   margin-top: 0px !important;
@@ -1058,9 +1058,6 @@ body > div#main-content {
 }
 .mt-8 {
   margin-top: 2rem;
-}
-.\!mb-2 {
-  margin-bottom: 0.5rem !important;
 }
 .block {
   display: block;

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -1761,6 +1761,9 @@ body > div#main-content {
 .pt-8 {
   padding-top: 2rem;
 }
+.pt-16 {
+  padding-top: 4rem;
+}
 .text-left {
   text-align: left;
 }

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -1173,6 +1173,12 @@ body > div#main-content {
 .max-h-60 {
   max-height: 15rem;
 }
+.max-h-full {
+  max-height: 100%;
+}
+.max-h-\[80vh\] {
+  max-height: 80vh;
+}
 .min-h-36 {
   min-height: 9rem;
 }
@@ -1439,6 +1445,9 @@ body > div#main-content {
 }
 .self-end {
   align-self: flex-end;
+}
+.overflow-auto {
+  overflow: auto;
 }
 .overflow-hidden {
   overflow: hidden;

--- a/docs/florida/has.html
+++ b/docs/florida/has.html
@@ -2,10 +2,10 @@
 <html lang="en-US">
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="https://datarepublican.com/florida/">
-  <script>location="https://datarepublican.com/florida/"</script>
-  <meta http-equiv="refresh" content="0; url=https://datarepublican.com/florida/">
+  <link rel="canonical" href="http://localhost:4000/florida/">
+  <script>location="http://localhost:4000/florida/"</script>
+  <meta http-equiv="refresh" content="0; url=http://localhost:4000/florida/">
   <meta name="robots" content="noindex">
   <h1>Redirecting&hellip;</h1>
-  <a href="https://datarepublican.com/florida/">Click here if you are not redirected.</a>
+  <a href="http://localhost:4000/florida/">Click here if you are not redirected.</a>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741012586">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741012586">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741022281">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741022281">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -43,16 +43,16 @@ $(document).ready(function() {
 <meta property="og:locale" content="en_US" />
 <meta name="description" content="Tracking where the money goes" />
 <meta property="og:description" content="Tracking where the money goes" />
-<link rel="canonical" href="https://datarepublican.com/" />
-<meta property="og:url" content="https://datarepublican.com/" />
+<link rel="canonical" href="http://localhost:4000/" />
+<meta property="og:url" content="http://localhost:4000/" />
 <meta property="og:site_name" content="DataRepublican" />
-<meta property="og:image" content="https://datarepublican.com/assets/images/og-3-1.png" />
+<meta property="og:image" content="http://localhost:4000/assets/images/og-3-1.png" />
 <meta property="og:type" content="website" />
 <meta name="twitter:card" content="summary_large_image" />
-<meta property="twitter:image" content="https://datarepublican.com/assets/images/og-3-1.png" />
+<meta property="twitter:image" content="http://localhost:4000/assets/images/og-3-1.png" />
 <meta property="twitter:title" content="Exposing where the money flows" />
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"WebSite","description":"Tracking where the money goes","headline":"Exposing where the money flows","image":"https://datarepublican.com/assets/images/og-3-1.png","name":"DataRepublican","url":"https://datarepublican.com/"}</script>
+{"@context":"https://schema.org","@type":"WebSite","description":"Tracking where the money goes","headline":"Exposing where the money flows","image":"http://localhost:4000/assets/images/og-3-1.png","name":"DataRepublican","url":"http://localhost:4000/"}</script>
 <!-- End Jekyll SEO tag -->
 
 </head>

--- a/docs/officers/bulk.html
+++ b/docs/officers/bulk.html
@@ -2,10 +2,10 @@
 <html lang="en-US">
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="https://datarepublican.com/officers/bulk/">
-  <script>location="https://datarepublican.com/officers/bulk/"</script>
-  <meta http-equiv="refresh" content="0; url=https://datarepublican.com/officers/bulk/">
+  <link rel="canonical" href="http://localhost:4000/officers/bulk/">
+  <script>location="http://localhost:4000/officers/bulk/"</script>
+  <meta http-equiv="refresh" content="0; url=http://localhost:4000/officers/bulk/">
   <meta name="robots" content="noindex">
   <h1>Redirecting&hellip;</h1>
-  <a href="https://datarepublican.com/officers/bulk/">Click here if you are not redirected.</a>
+  <a href="http://localhost:4000/officers/bulk/">Click here if you are not redirected.</a>
 </html>

--- a/docs/redirects.json
+++ b/docs/redirects.json
@@ -1,1 +1,1 @@
-{"/officers/bulk.html":"https://datarepublican.com/officers/bulk/","/tip":"https://datarepublican.com/donate/","/florida/has":"https://datarepublican.com/florida/"}
+{"/officers/bulk.html":"http://localhost:4000/officers/bulk/","/tip":"http://localhost:4000/donate/","/florida/has":"http://localhost:4000/florida/"}

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741050497">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741050497">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741051087">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741051087">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -773,12 +773,15 @@ $(document).ready(function() {
   }
   #graph-container {
     width: 100%;
-    height: 80vh;      /* or calc(100vh - someOffset) */
+    height: 70vh;
     position: relative;
-    overflow: hidden;  /* if you like; up to you */
-    display: flex;     /* Add flexbox to center content */
-    justify-content: center; /* Center horizontally */
-    align-items: flex-start; /* Align to the top instead of center */
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.375rem;
   }
   #legend {
     display: flex;
@@ -978,7 +981,24 @@ It shows the generated graph and a legend, plus a button to go back to the searc
 <div id="rootSummary" class="mb-4 p-2 md:px-4 md:pt-3 border rounded text-sm bg-white"></div>
 
 <!-- Where the graph renders -->
-<div id="graph-container" class="border rounded flex items-center justify-center bg-white">
+<div id="graph-container">
+  <div class="absolute bottom-4 right-4 z-10 flex flex-col gap-1">
+    <button id="zoomIn" class="p-2 rounded min-w-0 mr-0 bg-black/60 hover:bg-black text-white">
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
+      </svg>
+    </button>
+    <button id="zoomOut" class="p-2 rounded min-w-0 mr-0 bg-black/60 hover:bg-black text-white">
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4"/>
+      </svg>
+    </button>
+    <button id="zoomFit" class="p-2 rounded min-w-0 mr-0 bg-black/60 hover:bg-black text-white">
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-5V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5"/>
+      </svg>
+    </button>
+  </div>
   <svg id="graph" width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
     <defs>
       <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
@@ -989,6 +1009,7 @@ It shows the generated graph and a legend, plus a button to go back to the searc
     </defs>
     <g id="graph-content"></g>
   </svg>
+
   <!-- Add loading overlay with the same styling as in expose/index.html -->
   <div id="loading" class="absolute inset-0 flex flex-col items-center justify-start bg-white pt-4 h-full z-30">
     <div class="text-center">
@@ -1006,6 +1027,8 @@ It shows the generated graph and a legend, plus a button to go back to the searc
     <img src="../assets/images/loading.svg" class="loading-spinner" style="width:32px;height:32px" alt="Loading...">
   </div>
 </div>
+
+
 
 <!-- Download button -->
 <div class="mt-2 text-right">
@@ -3646,6 +3669,17 @@ function zoomToFitAll() {
     d3.zoomIdentity.translate(translateX, translateY).scale(scale)
   );
 }
+
+// Handle zoom controls
+document.getElementById('zoomIn').onclick = () => {
+  d3.select('#graph').transition().duration(300).call(zoom.scaleBy, 1.3);
+};
+
+document.getElementById('zoomOut').onclick = () => {
+  d3.select('#graph').transition().duration(300).call(zoom.scaleBy, 0.7);
+};
+
+document.getElementById('zoomFit').onclick = zoomToFitAll;
 
 // Remove drag functions since we disabled node dragging
 

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741019912">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741019912">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741027815">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741027815">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -834,6 +834,70 @@ $(document).ready(function() {
   .legend-item.disabled {
     opacity: 0.5;
   }
+  
+  /* Hover effects - using !important to override any inline styles */
+  .node rect:hover {
+    stroke: #2563EB !important;
+    stroke-width: 3px !important;
+  }
+  
+  .link:hover {
+    stroke: #2563EB !important;
+    stroke-width: 4px !important;
+  }
+  
+  /* Arrow styling */
+  .arrow-path {
+    fill: #94A3B8;
+  }
+  
+  #arrow-highlighted .arrow-path {
+    fill: #2563EB !important;
+  }
+  
+  /* Label styling */
+  .label-bg:hover {
+    fill: #2563EB !important;
+  }
+  
+  /* Make all text in a label group white when the background is hovered */
+  .link-label-group:hover .link-label {
+    fill: white !important;
+  }
+  
+  /* Custom data attribute selectors for connected elements */
+  .link[data-highlighted="true"] {
+    stroke: #2563EB !important;
+    stroke-width: 4px !important;
+  }
+  
+  .node rect[data-highlighted="true"] {
+    stroke: #2563EB !important;
+    stroke-width: 3px !important;
+  }
+  
+  .label-bg[data-highlighted="true"] {
+    fill: #2563EB !important;
+  }
+  
+  .link-label[data-highlighted="true"] {
+    fill: white !important;
+  }
+  
+  /* When hovering a node, highlight connected links */
+  .node:hover ~ .links .link {
+    stroke: #2563EB !important;
+    stroke-width: 4px !important;
+  }
+  
+  /* When hovering a node, highlight connected labels */
+  .node:hover ~ .label-group .link-label-group .label-bg {
+    fill: #2563EB !important;
+  }
+  
+  .node:hover ~ .label-group .link-label-group .link-label {
+    fill: white !important;
+  }
 </style>
 
 <!-- 
@@ -907,11 +971,14 @@ It shows the generated graph and a legend, plus a button to go back to the searc
 <!-- Where the graph renders -->
 <div id="graph-container" class="border rounded flex items-center justify-center bg-white">
   <svg id="graph" width="100%" height="100%">
-    <!-- Arrow marker definition for edges -->
     <defs>
       <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
         markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-        <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-path" />
+        <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-path" fill="#94A3B8" />
+      </marker>
+      <marker id="arrow-highlighted" viewBox="0 0 10 10" refX="5" refY="5"
+        markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-path" fill="#2563EB" />
       </marker>
     </defs>
     <g id="graph-content"></g>
@@ -935,6 +1002,9 @@ It shows the generated graph and a legend, plus a button to go back to the searc
 let allReverseIndex = new Map();      // token -> array of lineIDs (with ranges)
 let allSubjects = [];                 // lines from subjects.csv (index = line-1)
 let allBullets = new Map();           // subject -> { bullet_point1, bullet_point2 }
+let globalSubjectsMap = new Map();    // subject name -> bullet info
+let parsedRelations = [];             // parsed relations data
+let parsedIntergraph = [];            // parsed intergraph edges data
 let searchInProgress = false;
 let searchCanceled = false;
 let hasInitialDataLoaded = false;
@@ -964,7 +1034,7 @@ let labelElements = null;
 
 // We store all graph edges in memory so toggling categories is easy:
 let globalNodesMap = new Map();  // subject -> bullet info
-let globalAllEdges = [];         // all edges (including duplicates filtered out)
+let globalAllEdges = new Map();  // key -> edge object
 let globalActiveCategories = new Set(); // which categories are currently on display
 
 // Force simulation parameters
@@ -1000,7 +1070,12 @@ $(document).ready(async function() {
 
   // If we have ?subject=, go straight to GraphViz mode after data loads
   if (subj) {
-    renderGraphForSubject(subj);
+    try {
+      await renderGraphForSubject(subj);
+    } catch (error) {
+      console.error("Error rendering graph:", error);
+      $('#statusMessage').text(`Error: ${error.message}`);
+    }
   }
 
   // Otherwise, remain in search mode, but if the user typed any text in ?search= param, do that:
@@ -1118,11 +1193,73 @@ async function loadBulletsCSV(zipUrl, csvFile) {
   for (let row of parsed.data) {
     const s = row['subject']?.trim() ?? '';
     if (!s) continue;
-    allBullets.set(s, {
+    const bulletInfo = {
       bullet_point1: row['bullet_point1'] || '',
       bullet_point2: row['bullet_point2'] || ''
-    });
+    };
+    allBullets.set(s, bulletInfo);
+    globalSubjectsMap.set(s, bulletInfo);
   }
+}
+
+// Function to load relations data for a specific subject
+async function loadRelationsData(subjectName) {
+  try {
+    // figure out which partition
+    const partitionIdx = partitionIndex(subjectName);
+    let pStr = partitionIdx.toString().padStart(2,'0');
+    const relationsZip = `relations_${pStr}.zip`;
+    
+    console.log(`Loading relations data for ${subjectName} from ${relationsZip}`);
+    
+    const resp = await fetch(relationsZip);
+    if (!resp.ok) {
+      throw new Error(`Unable to fetch ${relationsZip}: ${resp.status} ${resp.statusText}`);
+    }
+    
+    const buffer = await resp.arrayBuffer();
+    const z = await JSZip.loadAsync(buffer);
+    
+    // Check if files exist in the zip
+    if (!z.file('relations.csv')) {
+      throw new Error(`Missing relations.csv in ${relationsZip}`);
+    }
+    
+    // Parse relations.csv
+    const relationsCsv = await z.file('relations.csv').async('string');
+    parsedRelations = Papa.parse(relationsCsv, { 
+      header: true, 
+      skipEmptyLines: true 
+    }).data;
+    
+    console.log(`Loaded ${parsedRelations.length} relations`);
+    
+    // Optionally load intergraph_edges.csv if it exists
+    if (z.file('intergraph_edges.csv')) {
+      const interCsv = await z.file('intergraph_edges.csv').async('string');
+      parsedIntergraph = Papa.parse(interCsv, { 
+        header: true, 
+        skipEmptyLines: true 
+      }).data;
+      console.log(`Loaded ${parsedIntergraph.length} intergraph edges`);
+    } else {
+      console.log('No intergraph_edges.csv found in zip');
+      parsedIntergraph = [];
+    }
+    
+    return true;
+  } catch (error) {
+    console.error("Error loading relations data:", error);
+    $('#statusMessage').text(`Error loading relations: ${error.message}`);
+    throw error;
+  }
+}
+
+// Helper function to determine which partition a subject belongs to
+function partitionIndex(subject) {
+  // Use murmur hash to determine partition
+  const hash = murmurHash3.x86.hash32(subject);
+  return Math.abs(hash) % NUM_PARTITIONS;
 }
 
 
@@ -1285,113 +1422,75 @@ $('#backToSearch').on('click', function() {
 * GRAPH MODE
 ***************************************/
 async function renderGraphForSubject(subjectName) {
-  // Show loading indicator
-  $('#loading-indicator').show();
-  $('#graph-content').empty();
-
-  // Set the search param in the URL
-  const newUrl = new URL(window.location);
-  newUrl.searchParams.set('subject', subjectName);
-  window.history.pushState({}, '', newUrl);
-
-  // Put subject name in title
-  $('#graphTitle').text(subjectName);
-
-  // Summarize from bullets.csv if found
-  let bulletInfo = allBullets.get(subjectName) || {};
-  let b1 = bulletInfo.bullet_point1 || "";
-  let b2 = bulletInfo.bullet_point2 || "";
-  let summaryHtml = `<p class="mb-2"><strong>${escapeHtml(subjectName)}</strong></p>`;
-  if (b1) summaryHtml += `<p class="mb-2">${escapeHtml(b1)}</p>`;
-  if (b2) summaryHtml += `<p>${escapeHtml(b2)}</p>`;
-  if (!b1 && !b2) {
-    summaryHtml += `<p class="text-sm text-gray-600">(No extended info available.)</p>`;
-  }
-  $('#rootSummary').html(summaryHtml);
-
-  // Clear globals for new subject
-  globalNodesMap.clear();
-  globalAllEdges = [];
-  globalActiveCategories.clear();
-
-  // Initialize D3 graph
-  initializeD3Graph();
-
-  // Add the root node
-  addNodeIfNeeded(globalNodesMap, subjectName);
-
-  // figure out which partition
-  const partitionIdx = partitionIndex(subjectName);
-  let pStr = partitionIdx.toString().padStart(2,'0');
-  const relationsZip = `relations_${pStr}.zip`;
-
   try {
-    // Show loading status
-    $('#graphInstructions').html(`
-      <div class="flex items-center gap-2">
-        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
-        <span>Loading relationship data for ${escapeHtml(subjectName)}...</span>
-      </div>
-    `);
-
-    const resp = await fetch(relationsZip);
-    if (!resp.ok) {
-      throw new Error(`Unable to fetch ${relationsZip}`);
+    // Show loading indicator
+    $('#loading-indicator').show();
+    $('#graphInstructions').hide();
+    
+    // Clear any previous error messages
+    $('#graph-container').removeClass('error');
+    
+    // Get the subject data
+    const subject = globalSubjectsMap.get(subjectName);
+    if (!subject) {
+      throw new Error(`Subject "${subjectName}" not found`);
     }
-    const buffer = await resp.arrayBuffer();
-    const z = await JSZip.loadAsync(buffer);
-
-    // Update loading status
-    $('#graphInstructions').html(`
-      <div class="flex items-center gap-2">
-        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
-        <span>Parsing relationship data...</span>
-      </div>
-    `);
-
-    // parse relations.csv, relations_reverse.csv, intergraph_edges.csv
-    const relationsCsv     = await getZipText(z, 'relations.csv');
-    const revCsv           = await getZipText(z, 'relations_reverse.csv');
-    const interCsv         = await getZipText(z, 'intergraph_edges.csv');
-
-    const parsedRelations  = Papa.parse(relationsCsv,     { header:true, skipEmptyLines:true }).data;
-    const parsedReverse    = Papa.parse(revCsv,           { header:true, skipEmptyLines:true }).data;
-    const parsedIntergraph = Papa.parse(interCsv,         { header:true, skipEmptyLines:true }).data;
-
-    // Update loading status
-    $('#graphInstructions').html(`
-      <div class="flex items-center gap-2">
-        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
-        <span>Building relationship graph...</span>
-      </div>
-    `);
-
-    let edgesSet = new Set(); // to ensure no duplicates
-
+    
+    // Load relations data for this subject
+    await loadRelationsData(subjectName);
+    
+    // Reset global variables
+    globalNodesMap = new Map();
+    globalAllEdges = new Map();
+    
+    // Create nodes and edges for the graph
+    const nodes = [];
+    const edges = [];
+    const edgesSet = new Set();
+    
+    // Add the root subject node
+    const rootNode = {
+      id: subjectName,
+      bulletInfo: subject
+    };
+    nodes.push(rootNode);
+    
     // 1) Forward edges
     for (let row of parsedRelations) {
       let s = row.subject?.trim() || "";
+      let o = row.object?.trim() || "";
       if (s !== subjectName) continue;
-      let o = (row.object || "").trim();
       if (!o) continue;
-
+      
+      // Skip self-loops
+      if (s === o) continue;
+      
+      // Check if we should skip symmetrical duplicates
+      if (parseInt(row.is_symmetrical,10)===1) {
+        let hasMirror = parsedRelations.some(rel => {
+          return (rel.subject?.trim() === o && rel.object?.trim() === s);
+        });
+        if (hasMirror && s > o) continue;
+      }
+      
       addNodeIfNeeded(globalNodesMap, o);
       let c = row.category?.trim() || "UNKNOWN";
       let color = categoryColors[c] || categoryColors["UNKNOWN"];
       addEdge(edgesSet, globalAllEdges, s, o, (row.label||""), c, color);
     }
-
+    
     // 2) Reverse edges
-    for (let revRow of parsedReverse) {
-      let obj = revRow.object?.trim() || "";
-      if (obj !== subjectName) continue;
-
+    for (let revRow of parsedRelations) {
       let s = revRow.subject?.trim() || "";
+      let o = revRow.object?.trim() || "";
+      if (o !== subjectName) continue;
       if (!s) continue;
-
-      let symmetrical = parseInt(revRow.is_symmetrical,10) === 1;
-      if (symmetrical) {
-        // skip if forward set had the mirror
+      
+      // Skip self-loops
+      if (s === o) continue;
+      
+      // Check if we should skip symmetrical duplicates
+      if (parseInt(revRow.is_symmetrical,10)===1) {
         let hasMirror = parsedRelations.some(rel => {
           return (rel.subject?.trim() === subjectName && rel.object?.trim() === s);
         });
@@ -1402,17 +1501,17 @@ async function renderGraphForSubject(subjectName) {
       let color = categoryColors[c] || categoryColors["UNKNOWN"];
       addEdge(edgesSet, globalAllEdges, s, subjectName, (revRow.label||""), c, color);
     }
-
+    
     // 3) Intergraph edges
     const potentialEdges = [];
     for (let iRow of parsedIntergraph) {
       let rp = iRow.root_person?.trim() || "";
       if (rp !== subjectName) continue;
-
+      
       let s = iRow.subject?.trim() || "";
       let o = iRow.object?.trim() || "";
       if (!s || !o) continue;
-
+      
       if (globalNodesMap.has(s) && globalNodesMap.has(o)) {
         potentialEdges.push({
           from: s,
@@ -1435,75 +1534,63 @@ async function renderGraphForSubject(subjectName) {
       }
       finalInterEdges.push(pe);
     }
-    // Add them
-    for (let pe of finalInterEdges) {
-      let c = pe.category;
-      let color = categoryColors[c] || categoryColors["UNKNOWN"];
-      addEdge(edgesSet, globalAllEdges, pe.from, pe.to, pe.label, c, color);
-    }
-
-    // Initialize active categories
-    let uniqueCats = new Set(globalAllEdges.map(e => e.category));
-    for (let c of uniqueCats) {
-      globalActiveCategories.add(c);
-    }
-
-    // Render the legend
-    renderLegend([...uniqueCats]);
-
-    // Update loading status
-    $('#graphInstructions').html(`
-      <div class="flex items-center gap-2">
-        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
-        <span>Rendering graph with ${globalNodesMap.size} nodes and ${globalAllEdges.length} connections...</span>
-      </div>
-    `);
-
-    // Prepare data for D3
-    const nodes = [];
-    const edges = [];
     
-    // Add nodes
-    for (let [subject, bulletInfo] of globalNodesMap.entries()) {
+    // Add intergraph edges
+    for (let ie of finalInterEdges) {
+      let c = ie.category;
+      let color = categoryColors[c] || categoryColors["UNKNOWN"];
+      addEdge(edgesSet, globalAllEdges, ie.from, ie.to, ie.label, c, color);
+    }
+    
+    // Convert nodes map to array
+    for (let [id, bulletInfo] of globalNodesMap) {
+      if (id === subjectName) continue; // Skip root node, already added
       nodes.push({
-        id: subject,
+        id: id,
         bulletInfo: bulletInfo
       });
     }
     
-    // Add edges
-    for (let edge of globalAllEdges) {
-      edges.push({
-        source: edge.from,
-        target: edge.to,
-        from: edge.from,
-        to: edge.to,
-        label: edge.label,
-        category: edge.category,
-        color: edge.color
-      });
+    // Convert edges set to array
+    for (let edgeKey of edgesSet) {
+      const edge = globalAllEdges.get(edgeKey);
+      if (edge) {
+        edges.push(edge);
+      }
     }
     
-    // Render the D3 graph
+    // Render the graph
     renderD3Graph(subjectName, nodes, edges);
-
-    // Restore instructions
-    setTimeout(() => {
-      $('#graphInstructions').html(`
-        Below is a visualization of our selected subject's relationships, color-coded by category.  
-        <strong>Click any color</strong> in the legend below to toggle that category on/off. The graph will re-render automatically.  
-        Click "Download SVG" to get an offline copy of the image.
-      `);
-    }, 1000);
-
-  } catch (err) {
-    console.error(err);
-    $('#graph-container').html(
-      `<div class="p-2 text-center text-sm text-red-500">Error loading relationships: ${err}</div>`
-    );
-    $('#graphInstructions').html(`
-      <div class="text-red-500">Error: ${escapeHtml(err.message)}</div>
+    
+    // Update URL with subject
+    const url = new URL(window.location);
+    url.searchParams.set('subject', subjectName);
+    window.history.pushState({}, '', url);
+    
+    // Update page title
+    document.title = `${subjectName} - People Relations`;
+    
+    // Show instructions
+    $('#graphInstructions').show();
+  } catch (error) {
+    console.error("Error loading relationships:", error);
+    
+    // Hide loading indicator
+    $('#loading-indicator').hide();
+    
+    // Display error message to user
+    $('#graph-container').html(`
+      <div class="p-4 bg-red-50 border border-red-200 rounded-md text-red-800">
+        <h3 class="font-bold mb-2">Error loading relationships:</h3>
+        <p>${error.message || error}</p>
+        <p class="mt-2">Please try refreshing the page or selecting a different subject.</p>
+      </div>
     `);
+    
+    // Update instructions
+    $('#graphInstructions').html(`
+      <p class="text-red-600">An error occurred while loading the graph. Please try again.</p>
+    `).show();
   }
 }
 
@@ -1518,13 +1605,21 @@ function addNodeIfNeeded(map, subject) {
 }
 
 // Deduplicate edges
-function addEdge(edgesSet, edgesArray, from, to, label, category, color) {
+function addEdge(edgesSet, edgesMap, from, to, label, category, color) {
   let key = `${from}||${to}||${category}||${label}`;
   if (edgesSet.has(key)) {
     return; // skip duplicates
   }
   edgesSet.add(key);
-  edgesArray.push({ from, to, label, category, color });
+  
+  // Store in the map with the key
+  if (!(edgesMap instanceof Map)) {
+    console.error("edgesMap is not a Map:", edgesMap);
+    // Initialize as a Map if it's not already
+    edgesMap = new Map();
+  }
+  
+  edgesMap.set(key, { from, to, label, category, color });
 }
 
 // Partition
@@ -1748,8 +1843,100 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Hide loading indicator when rendering starts
   $('#loading-indicator').hide();
   
+  // Initialize container dimensions
+  const container = document.getElementById('graph-container');
+  width = container.clientWidth;
+  height = container.clientHeight;
+  
+  // Initialize zoom behavior if not already done
+  if (!zoom) {
+    zoom = d3.zoom()
+      .scaleExtent([0.1, 2])
+      .on('zoom', (event) => {
+        d3.select('#graph-content').attr('transform', event.transform);
+      });
+    
+    // Apply zoom behavior to SVG
+    d3.select('#graph')
+      .call(zoom)
+      .on('dblclick.zoom', null); // Disable double-click zoom
+  }
+  
+  // Reset zoom and pan
+  d3.select('#graph').call(
+    zoom.transform,
+    d3.zoomIdentity.translate(width/2, height/2)
+  );
+  
   // Create the graph content group
   const g = d3.select('#graph-content');
+  
+  // Add arrow markers for links
+  const defs = g.append('defs');
+  
+  // Regular arrow marker
+  defs.append('marker')
+    .attr('id', 'arrow')
+    .attr('viewBox', '0 -5 10 10')
+    .attr('refX', 10)
+    .attr('refY', 0)
+    .attr('markerWidth', 6)
+    .attr('markerHeight', 6)
+    .attr('orient', 'auto')
+    .append('path')
+    .attr('class', 'arrow-path')
+    .attr('d', 'M0,-5L10,0L0,5');
+    
+  // Highlighted arrow marker (blue)
+  defs.append('marker')
+    .attr('id', 'arrow-highlighted')
+    .attr('viewBox', '0 -5 10 10')
+    .attr('refX', 10)
+    .attr('refY', 0)
+    .attr('markerWidth', 6)
+    .attr('markerHeight', 6)
+    .attr('orient', 'auto')
+    .append('path')
+    .attr('fill', '#2563EB')
+    .attr('d', 'M0,-5L10,0L0,5');
+  
+  // Create a map of node IDs for quick lookup - make it global for other functions to use
+  window.nodeMap = new Map();
+  nodes.forEach(node => {
+    nodeMap.set(node.id, node);
+  });
+  
+  // Preprocess edges to ensure all source and target nodes exist
+  console.log(`Processing ${edges.length} edges...`);
+  const validEdges = edges.filter(edge => {
+    const sourceId = edge.from;
+    const targetId = edge.to;
+    
+    // Check if source and target nodes exist
+    const sourceExists = nodeMap.has(sourceId);
+    const targetExists = nodeMap.has(targetId);
+    
+    if (!sourceExists) {
+      console.warn(`Edge source node not found: ${sourceId}`);
+    }
+    if (!targetExists) {
+      console.warn(`Edge target node not found: ${targetId}`);
+    }
+    
+    // Only keep edges where both nodes exist
+    if (sourceExists && targetExists) {
+      // Set source and target properties for D3
+      edge.source = sourceId;
+      edge.target = targetId;
+      return true;
+    }
+    return false;
+  });
+  
+  console.log(`Filtered to ${validEdges.length} valid edges`);
+  
+  // Store the root subject for reference in other functions
+  window.rootSubject = rootSubject;
   
   // Separate root node from other nodes
   const rootNode = nodes.find(n => n.id === rootSubject);
@@ -1778,12 +1965,29 @@ function renderD3Graph(rootSubject, nodes, edges) {
   linkElements = g.append('g')
     .attr('class', 'links')
     .selectAll('path')
-    .data(edges)
+    .data(validEdges)
     .join('path')
     .attr('class', 'link')
     .attr('stroke', d => d.color)
     .attr('stroke-width', 2)
-    .attr('marker-end', 'url(#arrow)');
+    .attr('marker-end', 'url(#arrow)')
+    .attr('data-source', d => d.from)
+    .attr('data-target', d => d.to)
+    .style('cursor', 'pointer')
+    .on('mouseover', function(event, d) {
+      console.log('Link path hover:', d);
+      
+      // Get source and target IDs
+      const sourceId = d.from;
+      const targetId = d.to;
+      
+      // Highlight this connection
+      highlightConnection(sourceId, targetId);
+    })
+    .on('mouseout', function() {
+      console.log('Link path mouseout');
+      resetHighlights();
+    });
   
   // Create nodes
   nodeElements = g.append('g')
@@ -1798,15 +2002,28 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .on('drag', dragged)
       .on('end', dragEnded)
     );
-  
+    
   // Add rectangles to nodes
   nodeElements.append('rect')
     .attr('rx', 4)
     .attr('ry', 4)
     .attr('width', d => getNodeWidth(d))
     .attr('height', d => getNodeHeight(d))
-    .style('cursor', 'grab');
-  
+    .attr('fill', 'white')
+    .attr('stroke', d => d.id === rootSubject ? '#2563EB' : '#94A3B8')
+    .attr('stroke-width', d => d.id === rootSubject ? 3 : 1)
+    .style('cursor', 'grab')
+    .on('mouseover', function(event, d) {
+      console.log('Node rect hover:', d);
+      
+      // Highlight all connections to/from this node
+      highlightNodeConnections(d.id);
+    })
+    .on('mouseout', function() {
+      console.log('Node rect mouseout');
+      resetHighlights();
+    });
+    
   // Add text to nodes
   nodeElements.each(function(d) {
     const node = d3.select(this);
@@ -1824,7 +2041,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     y += 25;
     
     // Add bullet point 1 if available
-    if (bulletInfo.bullet_point1) {
+    if (bulletInfo && bulletInfo.bullet_point1) {
       const wrappedText = wrapText(bulletInfo.bullet_point1, 30);
       wrappedText.forEach(line => {
         node.append('text')
@@ -1837,7 +2054,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     }
     
     // Add bullet point 2 if available
-    if (bulletInfo.bullet_point2) {
+    if (bulletInfo && bulletInfo.bullet_point2) {
       y += 5; // Add a little extra space
       const wrappedText = wrapText(bulletInfo.bullet_point2, 30);
       wrappedText.forEach(line => {
@@ -1850,31 +2067,38 @@ function renderD3Graph(rootSubject, nodes, edges) {
       });
     }
   });
-  
+    
   // Create edge labels
   const labelGroup = g.append('g').attr('class', 'label-group');
   labelElements = labelGroup.selectAll('g')
-    .data(edges)
+    .data(validEdges)
     .join('g')
-    .attr('class', 'link-label-group');
+    .attr('class', 'link-label-group')
+    .attr('data-source', d => d.from)
+    .attr('data-target', d => d.to);
   
   // Add background pill for labels
   labelElements.append('rect')
     .attr('rx', 12)
     .attr('ry', 12)
     .attr('class', 'label-bg')
+    .attr('fill', '#F3F4F6')
+    .attr('width', 10) // Initial size, will be updated in ticked
+    .attr('height', 10)
+    .attr('x', -5)
+    .attr('y', -5)
     .style('cursor', 'pointer')
     .on('mouseover', function(event, d) {
-      d3.select(this).attr('fill', d.color);
-      d3.select(this.parentNode).selectAll('.link-label').attr('fill', 'white');
-      linkElements.filter(l => l === d).attr('stroke-width', 4);
+      console.log('Label bg hover:', d);
+      
+      // Highlight this connection
+      highlightConnection(d.from, d.to);
     })
     .on('mouseout', function() {
-      d3.select(this).attr('fill', '#F3F4F6');
-      d3.select(this.parentNode).selectAll('.link-label').attr('fill', '#475569');
-      linkElements.attr('stroke-width', 2);
+      console.log('Label bg mouseout');
+      resetHighlights();
     });
-  
+    
   // Add text labels with wrapping
   labelElements.each(function(d) {
     const labelGroup = d3.select(this);
@@ -1884,6 +2108,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     if (!label.trim()) {
       labelGroup.append('text')
         .attr('class', 'link-label')
+        .attr('fill', '#475569')
         .text("");
       return;
     }
@@ -1895,78 +2120,107 @@ function renderD3Graph(rootSubject, nodes, edges) {
     wrappedText.forEach((line, i) => {
       labelGroup.append('text')
         .attr('class', 'link-label')
+        .attr('fill', '#475569')
+        .attr('text-anchor', 'middle') // Center text
         .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
         .text(line);
     });
   });
   
-  // Add hover effects to nodes
-  nodeElements.on('mouseover', function(event, d) {
-    // Highlight this node
-    d3.select(this).select('rect')
-      .attr('stroke-width', 3)
-      .attr('stroke', '#2563EB');
+  // Helper function to highlight a connection between two nodes
+  function highlightConnection(sourceId, targetId) {
+    // Highlight the link
+    linkElements.filter(l => {
+      return (l.from === sourceId && l.to === targetId);
+    })
+    .style('stroke', '#2563EB')
+    .style('stroke-width', '4px')
+    .attr('marker-end', 'url(#arrow-highlighted)');
     
-    // Highlight connected edges and nodes
+    // Highlight source and target nodes
+    nodeElements.filter(n => n.id === sourceId || n.id === targetId)
+      .select('rect')
+      .style('stroke', '#2563EB')
+      .style('stroke-width', '3px');
+    
+    // Highlight the label
+    labelElements.filter(l => {
+      return (l.from === sourceId && l.to === targetId);
+    })
+    .each(function() {
+      d3.select(this).select('.label-bg')
+        .style('fill', '#2563EB');
+      d3.select(this).selectAll('.link-label')
+        .style('fill', 'white');
+    });
+  }
+  
+  // Helper function to highlight all connections to/from a node
+  function highlightNodeConnections(nodeId) {
+    // Highlight all links connected to this node
     linkElements.each(function(link) {
-      if (link.from === d.id || link.to === d.id) {
-        d3.select(this)
-          .attr('stroke-width', 4)
-          .attr('stroke', link.color);
-        
-        // Highlight connected node
-        const connectedId = link.from === d.id ? link.to : link.from;
-        nodeElements.filter(n => n.id === connectedId)
-          .select('rect')
-          .attr('stroke-width', 2)
-          .attr('stroke', link.color);
+      const sourceId = link.from;
+      const targetId = link.to;
+      
+      if (sourceId === nodeId || targetId === nodeId) {
+        // Highlight this connection
+        highlightConnection(sourceId, targetId);
       }
     });
-    
-    // Highlight related labels
-    labelElements.each(function(label) {
-      if (label.from === d.id || label.to === d.id) {
-        d3.select(this).select('.label-bg')
-          .attr('fill', label.color);
-        d3.select(this).selectAll('.link-label')
-          .attr('fill', 'white');
-      }
-    });
-  })
-  .on('mouseout', function() {
+  }
+  
+  // Helper function to reset all highlights
+  function resetHighlights() {
     // Reset node styles
     nodeElements.select('rect')
-      .attr('stroke-width', d => d.id === rootSubject ? 3 : 1)
-      .attr('stroke', d => d.id === rootSubject ? '#2563EB' : '#94A3B8');
+      .style('stroke', null)
+      .style('stroke-width', null)
+      .attr('stroke', d => d.id === rootSubject ? '#2563EB' : '#94A3B8')
+      .attr('stroke-width', d => d.id === rootSubject ? 3 : 1);
     
     // Reset edge styles
     linkElements
-      .attr('stroke-width', 2)
-      .attr('stroke', d => d.color);
+      .style('stroke', null)
+      .style('stroke-width', null)
+      .attr('stroke', d => d.color)
+      .attr('stroke-width', 2);
     
     // Reset label styles
     labelElements.select('.label-bg')
+      .style('fill', null)
       .attr('fill', '#F3F4F6');
     labelElements.selectAll('.link-label')
+      .style('fill', null)
       .attr('fill', '#475569');
-  });
+  }
   
   // Start the simulation with modified forces for structured layout
   simulation = d3.forceSimulation(nodes)
-    .force('link', d3.forceLink(edges)
+    .force('link', d3.forceLink()
+      .links(validEdges)
       .id(d => d.id)
       .distance(d => {
-        // Adjust link distance based on node sizes
-        const sourceNode = nodes.find(n => n.id === d.from);
-        const targetNode = nodes.find(n => n.id === d.to);
-        if (!sourceNode || !targetNode) return forceParams.linkDistance;
-        
-        const sourceSize = Math.sqrt(getNodeWidth(sourceNode) * getNodeHeight(sourceNode));
-        const targetSize = Math.sqrt(getNodeWidth(targetNode) * getNodeHeight(targetNode));
-        
-        // Base distance on node sizes plus padding
-        return (sourceSize + targetSize) / 2 + forceParams.linkDistance;
-      }))
+        try {
+          // Get source and target nodes
+          const sourceNode = d.source;
+          const targetNode = d.target;
+          
+          if (!sourceNode || !targetNode) {
+            console.warn("Missing node in link distance calculation");
+            return forceParams.linkDistance;
+          }
+          
+          const sourceSize = Math.sqrt(getNodeWidth(sourceNode) * getNodeHeight(sourceNode));
+          const targetSize = Math.sqrt(getNodeWidth(targetNode) * getNodeHeight(targetNode));
+          
+          // Base distance on node sizes plus padding
+          return (sourceSize + targetSize) / 2 + forceParams.linkDistance;
+        } catch (error) {
+          console.error("Error in link distance calculation:", error, d);
+          return forceParams.linkDistance;
+        }
+      })
+    )
     .force('charge', d3.forceManyBody()
       .strength(d => {
         // Stronger repulsion for structured layout
@@ -1995,280 +2249,484 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .alphaDecay(0.008) // Slower decay for more time to find optimal positions
     .velocityDecay(0.4)
     .on('tick', ticked);
-  
-  // Force an initial tick to position elements correctly
-  ticked();
-  
-  // Enable download button
-  $('#downloadBtn').show();
-  
-  // Auto-zoom to fit all nodes after simulation stabilizes
-  setTimeout(() => {
-    zoomToFitAll();
-    
-    // Run label overlap prevention multiple times during and after stabilization
-    preventLabelOverlaps();
-    
-    // Set up interval to repeatedly check for and fix label overlaps during simulation
-    const labelInterval = setInterval(() => {
-      preventLabelOverlaps();
-      
-      // Stop checking once simulation has cooled down
-      if (simulation.alpha() < 0.05) {
-        clearInterval(labelInterval);
-        // Final adjustment after simulation ends
-        setTimeout(() => {
-          preventLabelOverlaps();
-          ticked(); // Force one more update
-        }, 500);
-      }
-    }, 200);
-  }, 1000);
 }
 
-// Function to zoom to fit all nodes
-function zoomToFitAll() {
-  if (!nodeElements || !nodeElements.size()) return;
-  
-  // Get bounding box of all nodes
-  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-  
-  nodeElements.each(function(d) {
-    const nodeWidth = getNodeWidth(d);
-    const nodeHeight = getNodeHeight(d);
-    
-    minX = Math.min(minX, d.x - nodeWidth/2);
-    minY = Math.min(minY, d.y - nodeHeight/2);
-    maxX = Math.max(maxX, d.x + nodeWidth/2);
-    maxY = Math.max(maxY, d.y + nodeHeight/2);
-  });
-  
-  // Add padding
-  const padding = 50;
-  minX -= padding;
-  minY -= padding;
-  maxX += padding;
-  maxY += padding;
-  
-  const graphWidth = maxX - minX;
-  const graphHeight = maxY - minY;
-  
-  // Calculate scale to fit
-  const scale = Math.min(
-    width / graphWidth,
-    height / graphHeight,
-    1.5 // Max scale
-  );
-  
-  // Calculate center point
-  const centerX = minX + graphWidth/2;
-  const centerY = minY + graphHeight/2;
-  
-  // Apply zoom transform
-  d3.select('#graph').transition()
-    .duration(750)
-    .call(
-      zoom.transform,
-      d3.zoomIdentity
-        .translate(width/2, height/2)
-        .scale(scale)
-        .translate(-centerX, -centerY)
-    );
-}
-
-// Update the ticked function to properly position labels along their paths
+// Update the ticked function to properly position nodes, links, and labels
 function ticked() {
-  // Update node positions
-  nodeElements.attr('transform', d => {
-    // Constrain to bounds
-    d.x = Math.max(forceParams.bounds.left, Math.min(width - forceParams.bounds.right, d.x));
-    d.y = Math.max(forceParams.bounds.top, Math.min(height - forceParams.bounds.bottom, d.y));
-    return `translate(${d.x - getNodeWidth(d) / 2}, ${d.y - getNodeHeight(d) / 2})`;
-  });
-  
-  // Update link paths with improved orthogonal routing
-  linkElements.attr('d', d => {
-    const sourceNode = nodeElements.filter(n => n.id === d.from).datum();
-    const targetNode = nodeElements.filter(n => n.id === d.to).datum();
-    
-    if (!sourceNode || !targetNode) return '';
-    
-    const sourceWidth = getNodeWidth(sourceNode);
-    const sourceHeight = getNodeHeight(sourceNode);
-    const targetWidth = getNodeWidth(targetNode);
-    const targetHeight = getNodeHeight(targetNode);
-    
-    // Calculate source and target points on the edges of the rectangles
-    const sourceX = sourceNode.x;
-    const sourceY = sourceNode.y;
-    const targetX = targetNode.x;
-    const targetY = targetNode.y;
-    
-    // Find intersection points with rectangles
-    const sourcePoint = findIntersectionPoint(
-      sourceX, sourceY, targetX, targetY,
-      sourceX - sourceWidth/2, sourceY - sourceHeight/2,
-      sourceWidth, sourceHeight
-    );
-    
-    const targetPoint = findIntersectionPoint(
-      targetX, targetY, sourceX, sourceY,
-      targetX - targetWidth/2, targetY - targetHeight/2,
-      targetWidth, targetHeight
-    );
-    
-    if (!sourcePoint || !targetPoint) return '';
-    
-    // Create orthogonal (right-angled) paths with better routing
-    // For structured layout, we want to route from top to bottom
-    // with horizontal segments as needed
-    
-    // Calculate midpoint Y position - place it closer to the higher node
-    const sourceIsHigher = sourcePoint.y < targetPoint.y;
-    const higherY = Math.min(sourcePoint.y, targetPoint.y);
-    const lowerY = Math.max(sourcePoint.y, targetPoint.y);
-    const yDiff = lowerY - higherY;
-    
-    // Place the horizontal segment at 1/3 of the distance from the higher node
-    const midY = higherY + yDiff * (sourceIsHigher ? 0.33 : 0.67);
-    
-    // Create the path
-    return `M${sourcePoint.x},${sourcePoint.y} 
-            L${sourcePoint.x},${midY} 
-            L${targetPoint.x},${midY} 
-            L${targetPoint.x},${targetPoint.y}`;
-  });
-  
-  // Update label positions with improved placement
-  labelElements.attr('transform', function(d) {
-    const path = linkElements.filter(l => l.source === d.source && l.target === d.target).node();
-    if (!path) return '';
-    
-    const pathLength = path.getTotalLength();
-    if (isNaN(pathLength) || pathLength === 0) return '';
-    
-    // For structured layout, we want to position labels further from the source node
-    // to prevent overlapping - use positions between 60% and 80% along the path
-    // This places labels closer to the target node and away from the crowded center
-    
-    // Calculate position based on source node's position in the layout
-    const sourceNode = nodeElements.filter(n => n.id === d.from).datum();
-    const targetNode = nodeElements.filter(n => n.id === d.to).datum();
-    
-    if (!sourceNode || !targetNode) {
-      // Fallback to midpoint if nodes not found
-      const midPoint = path.getPointAtLength(pathLength / 2);
-      d.labelX = midPoint.x;
-      d.labelY = midPoint.y;
-      return `translate(${midPoint.x}, ${midPoint.y})`;
-    }
-    
-    // Determine if this is a connection from root to child or between other nodes
-    const rootNode = d3.select('.node.root').datum();
-    const isRootToChild = sourceNode.id === rootNode.id;
-    
-    // Position labels at different points along the path based on connection type
-    let positionRatio;
-    
-    if (isRootToChild) {
-      // For root-to-child connections, position labels at 70% along the path
-      // This places them closer to the child nodes and away from the crowded center
-      positionRatio = 0.7;
-    } else {
-      // For other connections, use a position that's 60% along the path
-      positionRatio = 0.6;
-    }
-    
-    // Get the point at the calculated position
-    const labelPoint = path.getPointAtLength(pathLength * positionRatio);
-    
-    // Store the position for collision detection
-    d.labelX = labelPoint.x;
-    d.labelY = labelPoint.y;
-    d.pathLength = pathLength;
-    d.path = path;
-    d.positionRatio = positionRatio;
-    
-    return `translate(${labelPoint.x}, ${labelPoint.y})`;
-  });
-  
-  // Update label background sizes
-  labelElements.each(function(d) {
-    const labelTexts = d3.select(this).selectAll('.link-label');
-    if (!labelTexts.size()) return;
-    
-    // Calculate bounding box that encompasses all text elements
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-    
-    labelTexts.each(function() {
-      const bbox = this.getBBox();
-      minX = Math.min(minX, bbox.x);
-      minY = Math.min(minY, bbox.y);
-      maxX = Math.max(maxX, bbox.x + bbox.width);
-      maxY = Math.max(maxY, bbox.y + bbox.height);
+  try {
+    // Update node positions
+    nodeElements.attr('transform', d => {
+      // Constrain to bounds
+      d.x = Math.max(50, Math.min(width - 50, d.x));
+      d.y = Math.max(50, Math.min(height - 50, d.y));
+      return `translate(${d.x - getNodeWidth(d) / 2}, ${d.y - getNodeHeight(d) / 2})`;
     });
     
-    // Add padding
-    const padding = { x: 10, y: 6 };
+    // Update link paths with improved orthogonal routing
+    linkElements.attr('d', d => {
+      try {
+        // Get source and target IDs
+        const sourceId = d.from;
+        const targetId = d.to;
+        
+        if (!sourceId || !targetId) {
+          console.warn("Missing source or target ID in link path calculation:", d);
+          return '';
+        }
+        
+        // Get the actual node objects using the nodeMap
+        const sourceNode = nodeMap.get(sourceId);
+        const targetNode = nodeMap.get(targetId);
+        
+        if (!sourceNode || !targetNode) {
+          console.warn("Missing node for link in ticked:", 
+                      !sourceNode ? `source: ${sourceId}` : `target: ${targetId}`);
+          return '';
+        }
+        
+        // Calculate dimensions
+        const sourceWidth = getNodeWidth(sourceNode);
+        const sourceHeight = getNodeHeight(sourceNode);
+        const targetWidth = getNodeWidth(targetNode);
+        const targetHeight = getNodeHeight(targetNode);
+        
+        // Calculate source and target centers
+        const sourceX = sourceNode.x;
+        const sourceY = sourceNode.y;
+        const targetX = targetNode.x;
+        const targetY = targetNode.y;
+        
+        // Find intersection points with rectangles
+        const sourcePoint = findIntersectionPoint(
+          sourceX, sourceY, targetX, targetY,
+          sourceX - sourceWidth/2, sourceY - sourceHeight/2,
+          sourceWidth, sourceHeight
+        );
+        
+        const targetPoint = findIntersectionPoint(
+          targetX, targetY, sourceX, sourceY,
+          targetX - targetWidth/2, targetY - targetHeight/2,
+          targetWidth, targetHeight
+        );
+        
+        if (!sourcePoint || !targetPoint) {
+          console.warn("Could not find intersection points for link:", sourceId, targetId);
+          // Fallback to direct line between centers
+          return `M${sourceX},${sourceY} L${targetX},${targetY}`;
+        }
+        
+        // Create orthogonal (right-angled) paths with better routing
+        // Calculate midpoint Y position - place it closer to the higher node
+        const sourceIsHigher = sourcePoint.y < targetPoint.y;
+        const higherY = Math.min(sourcePoint.y, targetPoint.y);
+        const lowerY = Math.max(sourcePoint.y, targetPoint.y);
+        const yDiff = lowerY - higherY;
+        
+        // Place the horizontal segment at 1/3 of the distance from the higher node
+        const midY = higherY + yDiff * (sourceIsHigher ? 0.33 : 0.67);
+        
+        // Create the path
+        return `M${sourcePoint.x},${sourcePoint.y} 
+                L${sourcePoint.x},${midY} 
+                L${targetPoint.x},${midY} 
+                L${targetPoint.x},${targetPoint.y}`;
+      } catch (error) {
+        console.error("Error in link path calculation:", error, d);
+        return '';
+      }
+    });
     
-    d3.select(this).select('.label-bg')
-      .attr('x', minX - padding.x)
-      .attr('y', minY - padding.y)
-      .attr('width', maxX - minX + padding.x * 2)
-      .attr('height', maxY - minY + padding.y * 2);
-  });
+    // Update label positions
+    labelElements.each(function(d) {
+      try {
+        const labelGroup = d3.select(this);
+        
+        // Get source and target IDs
+        const sourceId = d.from;
+        const targetId = d.to;
+        
+        if (!sourceId || !targetId) {
+          console.warn("Missing source or target ID in label positioning");
+          return;
+        }
+        
+        // Find the path element for this edge
+        const path = d3.select(`path.link[data-source="${sourceId}"][data-target="${targetId}"]`).node();
+        
+        let midX, midY;
+        
+        // If we have a path, position the label at its midpoint
+        if (path) {
+          const pathLength = path.getTotalLength();
+          if (pathLength) {
+            // Store the path for later use in overlap prevention
+            d.path = path;
+            
+            // Get the midpoint of the path
+            const midPoint = path.getPointAtLength(pathLength / 2);
+            midX = midPoint.x;
+            midY = midPoint.y;
+          } else {
+            // Fallback if path length is 0
+            const sourceNode = nodeMap.get(sourceId);
+            const targetNode = nodeMap.get(targetId);
+            
+            if (!sourceNode || !targetNode) {
+              console.warn("Missing node in label positioning fallback");
+              return;
+            }
+            
+            midX = (sourceNode.x + targetNode.x) / 2;
+            midY = (sourceNode.y + targetNode.y) / 2;
+          }
+        } else {
+          // Fallback: position between nodes if no path is found
+          const sourceNode = nodeMap.get(sourceId);
+          const targetNode = nodeMap.get(targetId);
+          
+          if (!sourceNode || !targetNode) {
+            console.warn("Missing node in label positioning fallback");
+            return;
+          }
+          
+          midX = (sourceNode.x + targetNode.x) / 2;
+          midY = (sourceNode.y + targetNode.y) / 2;
+        }
+        
+        // Store label position for overlap prevention
+        d.labelX = midX;
+        d.labelY = midY;
+        
+        // Update transform
+        labelGroup.attr('transform', `translate(${midX}, ${midY})`);
+        
+        // Size the background rectangle based on the text content
+        const textElements = labelGroup.selectAll('.link-label');
+        let maxWidth = 0;
+        let totalHeight = 0;
+        
+        textElements.each(function() {
+          const bbox = this.getBBox();
+          maxWidth = Math.max(maxWidth, bbox.width);
+          totalHeight += bbox.height;
+        });
+        
+        // Add padding to the background rectangle
+        const padding = 8;
+        
+        // Update background rectangle size with padding
+        labelGroup.select('.label-bg')
+          .attr('width', maxWidth + padding * 2)
+          .attr('height', totalHeight + padding * 2)
+          .attr('x', -maxWidth / 2 - padding)
+          .attr('y', -totalHeight / 2 - padding);
+      } catch (error) {
+        console.error("Error in label positioning:", error, d);
+      }
+    });
+    
+    // Run label overlap prevention
+    preventLabelOverlaps();
+  } catch (error) {
+    console.error("Error in ticked function:", error);
+  }
 }
 
-function dragStarted(event, d) {
-  if (!event.active) simulation.alphaTarget(0.3).restart();
-  d.fx = d.x;
-  d.fy = d.y;
-  d3.select(this).style('cursor', 'grabbing');
+// Function to prevent label overlaps with nodes
+function preventLabelOverlaps() {
+  try {
+    // For each label, check if it overlaps with any node
+    labelElements.each(function(d) {
+      try {
+        const labelGroup = d3.select(this);
+        const labelBg = labelGroup.select('.label-bg');
+        
+        // Skip if no background element
+        if (labelBg.empty()) return;
+        
+        // Get the label's bounding box
+        const labelBBox = labelBg.node().getBBox();
+        if (!labelBBox) return;
+        
+        // Current label position
+        const labelX = d.labelX || 0;
+        const labelY = d.labelY || 0;
+        
+        // Create a rectangle representing the label's current position
+        const labelRect = {
+          x: labelX - labelBBox.width / 2,
+          y: labelY - labelBBox.height / 2,
+          width: labelBBox.width,
+          height: labelBBox.height
+        };
+        
+        // Check for overlaps with nodes
+        let maxOverlap = 0;
+        nodeElements.each(function(nodeData) {
+          const nodeRect = {
+            x: nodeData.x - getNodeWidth(nodeData) / 2,
+            y: nodeData.y - getNodeHeight(nodeData) / 2,
+            width: getNodeWidth(nodeData),
+            height: getNodeHeight(nodeData)
+          };
+          
+          // Calculate overlap area
+          const overlapArea = calculateOverlapArea(labelRect, nodeRect);
+          maxOverlap = Math.max(maxOverlap, overlapArea);
+        });
+        
+        // If there's significant overlap, try to reposition the label
+        if (maxOverlap > 0) {
+          // Get source and target IDs
+          const sourceId = d.from;
+          const targetId = d.to;
+          
+          if (!sourceId || !targetId) return;
+          
+          // Find the path for this label
+          let path = d.path;
+          
+          // If path is not stored, try to find it
+          if (!path) {
+            path = d3.select(`path[data-source="${sourceId}"][data-target="${targetId}"]`).node();
+            if (!path) {
+              console.log('No path found for label:', sourceId, targetId);
+              return;
+            }
+            d.path = path;
+          }
+          
+          const pathLength = path.getTotalLength();
+          if (!pathLength || pathLength <= 0) {
+            console.log('Invalid path length:', pathLength);
+            return;
+          }
+          
+          // Try different positions along the path
+          let bestPosition = 0.5; // Default to midpoint
+          let minOverlap = maxOverlap;
+          
+          // Test positions at 5% increments
+          for (let pos = 0.05; pos <= 0.95; pos += 0.05) {
+            if (pos === 0.5) continue; // Skip the current position
+            
+            const testPoint = path.getPointAtLength(pathLength * pos);
+            
+            // Create a rectangle for this test position
+            const testRect = {
+              x: testPoint.x - labelBBox.width / 2,
+              y: testPoint.y - labelBBox.height / 2,
+              width: labelBBox.width,
+              height: labelBBox.height
+            };
+            
+            // Check overlap with all nodes
+            let testMaxOverlap = 0;
+            nodeElements.each(function(nodeData) {
+              const nodeRect = {
+                x: nodeData.x - getNodeWidth(nodeData) / 2,
+                y: nodeData.y - getNodeHeight(nodeData) / 2,
+                width: getNodeWidth(nodeData),
+                height: getNodeHeight(nodeData)
+              };
+              
+              const overlapArea = calculateOverlapArea(testRect, nodeRect);
+              testMaxOverlap = Math.max(testMaxOverlap, overlapArea);
+            });
+            
+            // If this position has less overlap, use it
+            if (testMaxOverlap < minOverlap) {
+              minOverlap = testMaxOverlap;
+              bestPosition = pos;
+            }
+          }
+          
+          // If we found a better position, update the label
+          if (bestPosition !== 0.5) {
+            const newPoint = path.getPointAtLength(pathLength * bestPosition);
+            
+            // Update stored position
+            d.labelX = newPoint.x;
+            d.labelY = newPoint.y;
+            
+            // Update transform
+            labelGroup.attr('transform', `translate(${newPoint.x}, ${newPoint.y})`);
+            
+            console.log('Repositioned label to reduce overlap:', sourceId, targetId, bestPosition);
+          }
+        }
+      } catch (error) {
+        console.error("Error in label overlap prevention for label:", error, d);
+      }
+    });
+  } catch (error) {
+    console.error("Error in preventLabelOverlaps:", error);
+  }
 }
 
-function dragged(event, d) {
-  d.fx = event.x;
-  d.fy = event.y;
-}
-
-function dragEnded(event, d) {
-  if (!event.active) simulation.alphaTarget(0);
-  d.fx = null;
-  d.fy = null;
-  d3.select(this).style('cursor', 'grab');
-}
-
-function getNodeWidth(d) {
-  // Calculate width based on text content
-  const minWidth = 200;
-  const textLength = d.id.length;
-  const bulletLength1 = d.bulletInfo?.bullet_point1?.length || 0;
-  const bulletLength2 = d.bulletInfo?.bullet_point2?.length || 0;
-  const maxTextLength = Math.max(textLength, bulletLength1 / 5, bulletLength2 / 5);
-  return Math.max(minWidth, maxTextLength * 7);
-}
-
-function getNodeHeight(d) {
-  // Calculate height based on text content
-  const baseHeight = 50; // Minimum height
-  const bulletInfo = d.bulletInfo;
-  let additionalHeight = 0;
+// Helper function to calculate the overlap area between two rectangles
+function calculateOverlapArea(rect1, rect2) {
+  // Calculate the overlap along the x-axis
+  const overlapX = Math.max(0, 
+    Math.min(rect1.x + rect1.width, rect2.x + rect2.width) - 
+    Math.max(rect1.x, rect2.x)
+  );
   
-  if (bulletInfo.bullet_point1) {
-    const lines1 = Math.ceil(bulletInfo.bullet_point1.length / 30);
-    additionalHeight += lines1 * 18;
+  // Calculate the overlap along the y-axis
+  const overlapY = Math.max(0, 
+    Math.min(rect1.y + rect1.height, rect2.y + rect2.height) - 
+    Math.max(rect1.y, rect2.y)
+  );
+  
+  // The overlap area is the product of the x and y overlaps
+  return overlapX * overlapY;
+}
+
+// Helper function to find intersection point of a line with a rectangle
+function findIntersectionPoint(x1, y1, x2, y2, rectX, rectY, rectWidth, rectHeight) {
+  // Line equation: y = mx + b
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  
+  // Handle vertical line
+  if (Math.abs(dx) < 0.001) {
+    // Check if the line intersects the top or bottom of the rectangle
+    if (x1 >= rectX && x1 <= rectX + rectWidth) {
+      if (y1 < y2) { // Line going down
+        return { x: x1, y: rectY };
+      } else { // Line going up
+        return { x: x1, y: rectY + rectHeight };
+      }
+    }
+    return null;
   }
   
-  if (bulletInfo.bullet_point2) {
-    const lines2 = Math.ceil(bulletInfo.bullet_point2.length / 30);
-    additionalHeight += lines2 * 18 + 5; // +5 for spacing
+  // Handle horizontal line
+  if (Math.abs(dy) < 0.001) {
+    // Check if the line intersects the left or right of the rectangle
+    if (y1 >= rectY && y1 <= rectY + rectHeight) {
+      if (x1 < x2) { // Line going right
+        return { x: rectX + rectWidth, y: y1 };
+      } else { // Line going left
+        return { x: rectX, y: y1 };
+      }
+    }
+    return null;
   }
   
-  return baseHeight + additionalHeight;
+  // Calculate slope and y-intercept
+  const m = dy / dx;
+  const b = y1 - m * x1;
+  
+  // Check intersection with each edge of the rectangle
+  const intersections = [];
+  
+  // Top edge: y = rectY
+  const topX = (rectY - b) / m;
+  if (topX >= rectX && topX <= rectX + rectWidth) {
+    intersections.push({ x: topX, y: rectY, dist: Math.hypot(topX - x1, rectY - y1) });
+  }
+  
+  // Bottom edge: y = rectY + rectHeight
+  const bottomX = (rectY + rectHeight - b) / m;
+  if (bottomX >= rectX && bottomX <= rectX + rectWidth) {
+    intersections.push({ x: bottomX, y: rectY + rectHeight, dist: Math.hypot(bottomX - x1, rectY + rectHeight - y1) });
+  }
+  
+  // Left edge: x = rectX
+  const leftY = m * rectX + b;
+  if (leftY >= rectY && leftY <= rectY + rectHeight) {
+    intersections.push({ x: rectX, y: leftY, dist: Math.hypot(rectX - x1, leftY - y1) });
+  }
+  
+  // Right edge: x = rectX + rectWidth
+  const rightY = m * (rectX + rectWidth) + b;
+  if (rightY >= rectY && rightY <= rectY + rectHeight) {
+    intersections.push({ x: rectX + rectWidth, y: rightY, dist: Math.hypot(rectX + rectWidth - x1, rightY - y1) });
+  }
+  
+  // Find the closest intersection point in the direction of the line
+  let closestPoint = null;
+  let minDist = Infinity;
+  
+  for (const point of intersections) {
+    // Check if the point is in the direction of the line
+    const dotProduct = (point.x - x1) * (x2 - x1) + (point.y - y1) * (y2 - y1);
+    if (dotProduct > 0) {
+      if (point.dist < minDist) {
+        minDist = point.dist;
+        closestPoint = point;
+      }
+    }
+  }
+  
+  return closestPoint;
 }
 
-function wrapText(text, maxCharsPerLine) {
-  if (!text) return [];
+// Helper function to get node width
+function getNodeWidth(node) {
+  // Default width if not calculated yet
+  if (!node._width) {
+    // Base width on text length
+    const textLength = node.id ? node.id.length : 10;
+    const bulletInfo = node.bulletInfo || {};
+    const bullet1 = bulletInfo.bullet_point1 || '';
+    const bullet2 = bulletInfo.bullet_point2 || '';
+    
+    // Find the longest line after wrapping
+    const wrappedBullet1 = wrapText(bullet1, 30);
+    const wrappedBullet2 = wrapText(bullet2, 30);
+    
+    let maxLineLength = textLength;
+    wrappedBullet1.forEach(line => {
+      maxLineLength = Math.max(maxLineLength, line.length);
+    });
+    wrappedBullet2.forEach(line => {
+      maxLineLength = Math.max(maxLineLength, line.length);
+    });
+    
+    // Calculate width based on the longest text
+    node._width = Math.max(
+      Math.min(maxLineLength * 8, 350),
+      150
+    );
+  }
+  return node._width;
+}
+
+// Helper function to get node height
+function getNodeHeight(node) {
+  // Default height if not calculated yet
+  if (!node._height) {
+    // Base height on number of text lines
+    const bulletInfo = node.bulletInfo || {};
+    const bullet1 = bulletInfo.bullet_point1 || '';
+    const bullet2 = bulletInfo.bullet_point2 || '';
+    
+    // Count lines after wrapping
+    const wrappedBullet1 = wrapText(bullet1, 30);
+    const wrappedBullet2 = wrapText(bullet2, 30);
+    
+    const bulletLines1 = wrappedBullet1.length;
+    const bulletLines2 = wrappedBullet2.length;
+    
+    // Calculate height based on number of lines
+    node._height = 30 + (bulletLines1 + bulletLines2) * 18;
+    
+    // Add extra padding if there are two bullet points
+    if (bulletLines1 > 0 && bulletLines2 > 0) {
+      node._height += 10;
+    }
+    
+    // Ensure minimum height
+    node._height = Math.max(node._height, 60);
+  }
+  return node._height;
+}
+
+// Helper function to wrap text to a specified width
+function wrapText(text, maxChars) {
+  if (!text) return [''];
   
   const words = text.split(' ');
   const lines = [];
@@ -2276,7 +2734,7 @@ function wrapText(text, maxCharsPerLine) {
   
   words.forEach(word => {
     const testLine = currentLine ? `${currentLine} ${word}` : word;
-    if (testLine.length <= maxCharsPerLine) {
+    if (testLine.length <= maxChars) {
       currentLine = testLine;
     } else {
       lines.push(currentLine);
@@ -2291,178 +2749,68 @@ function wrapText(text, maxCharsPerLine) {
   return lines;
 }
 
-function findIntersectionPoint(x1, y1, x2, y2, rectX, rectY, rectWidth, rectHeight) {
-  // Calculate rectangle corners
-  const corners = [
-    { x: rectX, y: rectY }, // top-left
-    { x: rectX + rectWidth, y: rectY }, // top-right
-    { x: rectX + rectWidth, y: rectY + rectHeight }, // bottom-right
-    { x: rectX, y: rectY + rectHeight } // bottom-left
-  ];
-  
-  // Check intersection with each edge of the rectangle
-  const edges = [
-    [corners[0], corners[1]], // top
-    [corners[1], corners[2]], // right
-    [corners[2], corners[3]], // bottom
-    [corners[3], corners[0]]  // left
-  ];
-  
-  for (const [p1, p2] of edges) {
-    const intersection = lineIntersection(x1, y1, x2, y2, p1.x, p1.y, p2.x, p2.y);
-    if (intersection) {
-      return intersection;
-    }
+// Drag functions for nodes
+function dragStarted(event, d) {
+  if (!event.active) simulation.alphaTarget(0.3).restart();
+  d.fx = d.x;
+  d.fy = d.y;
+  d3.select(this).select('rect').style('cursor', 'grabbing');
+}
+
+function dragged(event, d) {
+  d.fx = event.x;
+  d.fy = event.y;
+}
+
+function dragEnded(event, d) {
+  if (!event.active) simulation.alphaTarget(0);
+  // Keep root node fixed, release others
+  if (d.id !== rootSubject) {
+    d.fx = null;
+    d.fy = null;
   }
-  
-  // If no intersection found, return center of rectangle
-  return { x: rectX + rectWidth / 2, y: rectY + rectHeight / 2 };
+  d3.select(this).select('rect').style('cursor', 'grab');
 }
 
-function lineIntersection(x1, y1, x2, y2, x3, y3, x4, y4) {
-  // Calculate determinants
-  const den = (y4 - y3) * (x2 - x1) - (x4 - x3) * (y2 - y1);
-  if (den === 0) return null; // Lines are parallel
+// Function to zoom to fit all nodes
+function zoomToFitAll() {
+  // Get the bounds of all nodes
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
   
-  const ua = ((x4 - x3) * (y1 - y3) - (y4 - y3) * (x1 - x3)) / den;
-  const ub = ((x2 - x1) * (y1 - y3) - (y2 - y1) * (x1 - x3)) / den;
-  
-  // Check if intersection is on both line segments
-  if (ua < 0 || ua > 1 || ub < 0 || ub > 1) return null;
-  
-  // Calculate intersection point
-  const x = x1 + ua * (x2 - x1);
-  const y = y1 + ua * (y2 - y1);
-  
-  return { x, y };
-}
-
-// Improved label overlap prevention
-function preventLabelOverlaps() {
-  const labelData = labelElements.data();
-  if (!labelData.length) return;
-  
-  // First pass: group labels by their vertical position into rows
-  const verticalThreshold = 30;
-  const rows = [];
-  let currentRow = [];
-  
-  // Sort labels by y-position first
-  const sortedLabels = [...labelData].sort((a, b) => a.labelY - b.labelY);
-  
-  sortedLabels.forEach(label => {
-    if (!currentRow.length) {
-      currentRow.push(label);
-    } else {
-      const lastLabel = currentRow[currentRow.length - 1];
-      if (Math.abs(label.labelY - lastLabel.labelY) < verticalThreshold) {
-        currentRow.push(label);
-      } else {
-        rows.push([...currentRow]);
-        currentRow = [label];
-      }
-    }
+  nodeElements.each(function(d) {
+    const width = getNodeWidth(d);
+    const height = getNodeHeight(d);
+    
+    minX = Math.min(minX, d.x - width/2);
+    minY = Math.min(minY, d.y - height/2);
+    maxX = Math.max(maxX, d.x + width/2);
+    maxY = Math.max(maxY, d.y + height/2);
   });
   
-  // Add the last row
-  if (currentRow.length) rows.push(currentRow);
+  // Add padding
+  const padding = 50;
+  minX -= padding;
+  minY -= padding;
+  maxX += padding;
+  maxY += padding;
   
-  // Second pass: for each row, resolve horizontal overlaps
-  rows.forEach(row => {
-    if (row.length <= 1) return; // No overlaps with single label
-    
-    // Sort by x-position
-    row.sort((a, b) => a.labelX - b.labelX);
-    
-    // Get label widths and calculate minimum required space
-    const labelWidths = row.map(label => {
-      const labelIndex = labelData.indexOf(label);
-      const labelElement = d3.select(labelElements.nodes()[labelIndex]);
-      const labelBg = labelElement.select('.label-bg').node();
-      return labelBg ? labelBg.getBBox().width : 0;
-    });
-    
-    // Calculate total width and required spacing
-    const minSpacing = 30; // Increased minimum spacing between labels
-    
-    // Check for overlaps and adjust positions
-    for (let i = 0; i < row.length - 1; i++) {
-      const currentLabel = row[i];
-      const nextLabel = row[i + 1];
-      
-      const currentWidth = labelWidths[i];
-      const nextWidth = labelWidths[i + 1];
-      
-      const currentRight = currentLabel.labelX + (currentWidth / 2);
-      const nextLeft = nextLabel.labelX - (nextWidth / 2);
-      
-      // If labels overlap or are too close
-      if (nextLeft - currentRight < minSpacing) {
-        // Calculate how much we need to move
-        const moveDistance = (minSpacing - (nextLeft - currentRight)) / 2;
-        
-        // Move current label left and next label right
-        if (currentLabel.path && nextLabel.path) {
-          // Adjust position ratios to move labels apart
-          currentLabel.positionRatio = Math.max(0.4, currentLabel.positionRatio - 0.1);
-          nextLabel.positionRatio = Math.min(0.9, nextLabel.positionRatio + 0.1);
-          
-          // Update positions based on new ratios
-          const currentPoint = currentLabel.path.getPointAtLength(currentLabel.pathLength * currentLabel.positionRatio);
-          const nextPoint = nextLabel.path.getPointAtLength(nextLabel.pathLength * nextLabel.positionRatio);
-          
-          currentLabel.labelX = currentPoint.x;
-          currentLabel.labelY = currentPoint.y;
-          nextLabel.labelX = nextPoint.x;
-          nextLabel.labelY = nextPoint.y;
-          
-          // Update the DOM
-          const currentIndex = labelData.indexOf(currentLabel);
-          const nextIndex = labelData.indexOf(nextLabel);
-          
-          d3.select(labelElements.nodes()[currentIndex])
-            .attr('transform', `translate(${currentLabel.labelX}, ${currentLabel.labelY})`);
-          
-          d3.select(labelElements.nodes()[nextIndex])
-            .attr('transform', `translate(${nextLabel.labelX}, ${nextLabel.labelY})`);
-        } else {
-          // Fallback if path information is not available
-          currentLabel.labelX -= moveDistance;
-          nextLabel.labelX += moveDistance;
-          
-          const currentIndex = labelData.indexOf(currentLabel);
-          const nextIndex = labelData.indexOf(nextLabel);
-          
-          d3.select(labelElements.nodes()[currentIndex])
-            .attr('transform', `translate(${currentLabel.labelX}, ${currentLabel.labelY})`);
-          
-          d3.select(labelElements.nodes()[nextIndex])
-            .attr('transform', `translate(${nextLabel.labelX}, ${nextLabel.labelY})`);
-        }
-      }
-    }
-  });
+  // Calculate the scale and translate to fit all nodes
+  const graphWidth = maxX - minX;
+  const graphHeight = maxY - minY;
+  const scale = Math.min(width / graphWidth, height / graphHeight, 1);
   
-  // Third pass: stagger labels vertically within rows to further reduce overlaps
-  rows.forEach(row => {
-    if (row.length <= 2) return; // No need to stagger if only 1-2 labels
-    
-    row.forEach((label, i) => {
-      // Apply a slight vertical offset based on position in row
-      // Odd indices go up, even indices go down
-      const verticalOffset = (i % 2 === 0) ? -15 : 15;
-      
-      label.labelY += verticalOffset;
-      
-      // Update the DOM
-      const labelIndex = labelData.indexOf(label);
-      d3.select(labelElements.nodes()[labelIndex])
-        .attr('transform', `translate(${label.labelX}, ${label.labelY})`);
-    });
-  });
+  const translateX = width/2 - (minX + maxX)/2 * scale;
+  const translateY = height/2 - (minY + maxY)/2 * scale;
+  
+  // Apply the zoom transform
+  d3.select('#graph').transition().duration(750).call(
+    zoom.transform,
+    d3.zoomIdentity.translate(translateX, translateY).scale(scale)
+  );
 }
 </script>
-
+</body>
+</html>
     </main>
     
 <div class="flex justify-center">

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741029178">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741029178">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741031089">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741031089">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -1454,7 +1454,7 @@ async function renderGraphForSubject(subjectName) {
       bulletInfo: subject
     };
     nodes.push(rootNode);
-    
+
     // 1) Forward edges
     for (let row of parsedRelations) {
       let s = row.subject?.trim() || "";
@@ -1472,20 +1472,20 @@ async function renderGraphForSubject(subjectName) {
         });
         if (hasMirror && s > o) continue;
       }
-      
+
       addNodeIfNeeded(globalNodesMap, o);
       let c = row.category?.trim() || "UNKNOWN";
       let color = categoryColors[c] || categoryColors["UNKNOWN"];
       addEdge(edgesSet, globalAllEdges, s, o, (row.label||""), c, color);
     }
-    
+
     // 2) Reverse edges
     for (let revRow of parsedRelations) {
       let s = revRow.subject?.trim() || "";
       let o = revRow.object?.trim() || "";
       if (o !== subjectName) continue;
       if (!s) continue;
-      
+
       // Skip self-loops
       if (s === o) continue;
       
@@ -1501,17 +1501,17 @@ async function renderGraphForSubject(subjectName) {
       let color = categoryColors[c] || categoryColors["UNKNOWN"];
       addEdge(edgesSet, globalAllEdges, s, subjectName, (revRow.label||""), c, color);
     }
-    
+
     // 3) Intergraph edges
     const potentialEdges = [];
     for (let iRow of parsedIntergraph) {
       let rp = iRow.root_person?.trim() || "";
       if (rp !== subjectName) continue;
-      
+
       let s = iRow.subject?.trim() || "";
       let o = iRow.object?.trim() || "";
       if (!s || !o) continue;
-      
+
       if (globalNodesMap.has(s) && globalNodesMap.has(o)) {
         potentialEdges.push({
           from: s,
@@ -1866,7 +1866,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Reset zoom and pan
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(width/2, height/2)
+    d3.zoomIdentity.translate(width/2, height/2).scale(0.7) // Start with a zoomed-out view
   );
   
   // Create the graph content group
@@ -1879,10 +1879,10 @@ function renderD3Graph(rootSubject, nodes, edges) {
   defs.append('marker')
     .attr('id', 'arrow')
     .attr('viewBox', '0 -5 10 10')
-    .attr('refX', 10)
+    .attr('refX', 20) // Increased to move arrow away from node
     .attr('refY', 0)
-    .attr('markerWidth', 6)
-    .attr('markerHeight', 6)
+    .attr('markerWidth', 8) // Increased size
+    .attr('markerHeight', 8) // Increased size
     .attr('orient', 'auto')
     .append('path')
     .attr('class', 'arrow-path')
@@ -1892,10 +1892,10 @@ function renderD3Graph(rootSubject, nodes, edges) {
   defs.append('marker')
     .attr('id', 'arrow-highlighted')
     .attr('viewBox', '0 -5 10 10')
-    .attr('refX', 10)
+    .attr('refX', 20) // Increased to move arrow away from node
     .attr('refY', 0)
-    .attr('markerWidth', 6)
-    .attr('markerHeight', 6)
+    .attr('markerWidth', 8) // Increased size
+    .attr('markerHeight', 8) // Increased size
     .attr('orient', 'auto')
     .append('path')
     .attr('fill', '#2563EB')
@@ -2218,11 +2218,11 @@ function renderD3Graph(rootSubject, nodes, edges) {
           const sourceSize = Math.sqrt(getNodeWidth(sourceNode) * getNodeHeight(sourceNode));
           const targetSize = Math.sqrt(getNodeWidth(targetNode) * getNodeHeight(targetNode));
           
-          // Base distance on node sizes plus padding
-          return (sourceSize + targetSize) / 2 + forceParams.linkDistance;
+          // Base distance on node sizes plus padding - increased for better spacing
+          return (sourceSize + targetSize) / 2 + forceParams.linkDistance * 1.5; // Increased distance multiplier
         } catch (error) {
           console.error("Error in link distance calculation:", error, d);
-          return forceParams.linkDistance;
+          return forceParams.linkDistance * 1.5; // Increased default distance
         }
       })
     )
@@ -2230,28 +2230,28 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .strength(d => {
         // Stronger repulsion for structured layout
         const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
-        return forceParams.charge * (nodeSize / 200) * 1.5;
+        return forceParams.charge * (nodeSize / 200) * 2.0; // Increased repulsion
       })
-      .distanceMin(200)
-      .distanceMax(2000))
+      .distanceMin(250) // Increased minimum distance
+      .distanceMax(2500)) // Increased maximum distance
     .force('x', d3.forceX(d => {
       // Keep root node centered, let others spread horizontally
       if (d.id === rootSubject) return width / 2;
       return d.x; // Use pre-positioned x value
-    }).strength(d => d.id === rootSubject ? 1 : 0.2))
+    }).strength(d => d.id === rootSubject ? 1 : 0.15)) // Reduced strength to allow more movement
     .force('y', d3.forceY(d => {
       // Keep root node at top, others in row below
       if (d.id === rootSubject) return height * 0.2;
       return height * 0.7;
-    }).strength(0.3))
+    }).strength(0.2)) // Reduced strength to allow more movement
     .force('collision', d3.forceCollide().radius(d => {
       // Make collision radius based on node size plus padding
       const nodeWidth = getNodeWidth(d);
       const nodeHeight = getNodeHeight(d);
-      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 70; // Increased padding
+      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 100; // Increased padding significantly
     }).strength(1))
     .alpha(0.8) // Higher alpha for more movement
-    .alphaDecay(0.008) // Slower decay for more time to find optimal positions
+    .alphaDecay(0.006) // Slower decay for more time to find optimal positions
     .velocityDecay(0.4)
     .on('tick', ticked);
 }
@@ -2321,20 +2321,47 @@ function ticked() {
         }
         
         // Create orthogonal (right-angled) paths with better routing
-        // Calculate midpoint Y position - place it closer to the higher node
-        const sourceIsHigher = sourcePoint.y < targetPoint.y;
-        const higherY = Math.min(sourcePoint.y, targetPoint.y);
-        const lowerY = Math.max(sourcePoint.y, targetPoint.y);
-        const yDiff = lowerY - higherY;
+        // Calculate if nodes are more horizontal or vertical to each other
+        const dx = Math.abs(targetPoint.x - sourcePoint.x);
+        const dy = Math.abs(targetPoint.y - sourcePoint.y);
+        const isHorizontal = dx > dy;
         
-        // Place the horizontal segment at 1/3 of the distance from the higher node
-        const midY = higherY + yDiff * (sourceIsHigher ? 0.33 : 0.67);
+        // Create path with more segments to avoid running behind nodes
+        let path = '';
         
-        // Create the path
-        return `M${sourcePoint.x},${sourcePoint.y} 
-                L${sourcePoint.x},${midY} 
-                L${targetPoint.x},${midY} 
-                L${targetPoint.x},${targetPoint.y}`;
+        // Add a small offset to ensure arrows don't touch nodes
+        const arrowOffset = 10;
+        
+        // Adjust target point to account for arrow
+        const targetPointWithOffset = {
+          x: targetPoint.x + (sourcePoint.x > targetPoint.x ? arrowOffset : -arrowOffset),
+          y: targetPoint.y + (sourcePoint.y > targetPoint.y ? arrowOffset : -arrowOffset)
+        };
+        
+        if (isHorizontal) {
+          // For horizontal arrangement, use 3 segments with vertical middle segment
+          const midX = (sourcePoint.x + targetPointWithOffset.x) / 2;
+          path = `M${sourcePoint.x},${sourcePoint.y} 
+                  L${midX},${sourcePoint.y} 
+                  L${midX},${targetPointWithOffset.y} 
+                  L${targetPointWithOffset.x},${targetPointWithOffset.y}`;
+        } else {
+          // For vertical arrangement, use 3 segments with horizontal middle segment
+          const midY = (sourcePoint.y + targetPointWithOffset.y) / 2;
+          path = `M${sourcePoint.x},${sourcePoint.y} 
+                  L${sourcePoint.x},${midY} 
+                  L${targetPointWithOffset.x},${midY} 
+                  L${targetPointWithOffset.x},${targetPointWithOffset.y}`;
+        }
+        
+        // Store the path points for label positioning
+        d.pathPoints = {
+          source: sourcePoint,
+          target: targetPointWithOffset,
+          isHorizontal: isHorizontal
+        };
+        
+        return path;
       } catch (error) {
         console.error("Error in link path calculation:", error, d);
         return '';
@@ -2371,6 +2398,27 @@ function ticked() {
             const midPoint = path.getPointAtLength(pathLength / 2);
             midX = midPoint.x;
             midY = midPoint.y;
+            
+            // If we have stored path points, use them for better label positioning
+            if (d.pathPoints) {
+              const { source, target, isHorizontal } = d.pathPoints;
+              
+              if (isHorizontal) {
+                // For horizontal paths, position label above or below the middle segment
+                const midX = (source.x + target.x) / 2;
+                midY = source.y + (target.y - source.y) / 2;
+                
+                // Offset the label to avoid overlapping with the path
+                midY += (source.y > target.y) ? -20 : 20;
+              } else {
+                // For vertical paths, position label to the left or right of the middle segment
+                midX = source.x + (target.x - source.x) / 2;
+                const midY = (source.y + target.y) / 2;
+                
+                // Offset the label to avoid overlapping with the path
+                midX += (source.x > target.x) ? -20 : 20;
+              }
+            }
           } else {
             // Fallback if path length is 0
             const sourceNode = nodeMap.get(sourceId);
@@ -2448,7 +2496,8 @@ function preventLabelOverlaps() {
         y: d.y - getNodeHeight(d) / 2,
         width: getNodeWidth(d),
         height: getNodeHeight(d),
-        id: d.id
+        id: d.id,
+        type: 'node'
       });
     });
     
@@ -2477,7 +2526,8 @@ function preventLabelOverlaps() {
         edge: d,
         group: labelGroup,
         originalX: labelX,
-        originalY: labelY
+        originalY: labelY,
+        type: 'label'
       });
     });
     
@@ -2486,7 +2536,7 @@ function preventLabelOverlaps() {
       const labelRect = labelRects[i];
       let hasOverlap = true;
       let attempts = 0;
-      const maxAttempts = 10;
+      const maxAttempts = 10; // Limit repositioning attempts
       
       // Try to find a position without overlaps
       while (hasOverlap && attempts < maxAttempts) {
@@ -2519,11 +2569,14 @@ function preventLabelOverlaps() {
       }
       
       // Update the label position
-      labelRect.group.attr('transform', `translate(${labelRect.x + labelRect.width/2}, ${labelRect.y + labelRect.height/2})`);
+      const newX = labelRect.x + labelRect.width/2;
+      const newY = labelRect.y + labelRect.height/2;
+      
+      labelRect.group.attr('transform', `translate(${newX}, ${newY})`);
       
       // Update stored position for future reference
-      labelRect.edge.labelX = labelRect.x + labelRect.width/2;
-      labelRect.edge.labelY = labelRect.y + labelRect.height/2;
+      labelRect.edge.labelX = newX;
+      labelRect.edge.labelY = newY;
     }
   } catch (error) {
     console.error("Error in preventLabelOverlaps:", error);
@@ -2532,11 +2585,14 @@ function preventLabelOverlaps() {
 
 // Helper function to check if two rectangles overlap
 function rectsOverlap(rect1, rect2) {
+  // Add a buffer zone to ensure labels don't touch
+  const buffer = 15;
+  
   return !(
-    rect1.x + rect1.width < rect2.x ||
-    rect2.x + rect2.width < rect1.x ||
-    rect1.y + rect1.height < rect2.y ||
-    rect2.y + rect2.height < rect1.y
+    rect1.x + rect1.width + buffer < rect2.x ||
+    rect2.x + rect2.width + buffer < rect1.x ||
+    rect1.y + rect1.height + buffer < rect2.y ||
+    rect2.y + rect2.height + buffer < rect1.y
   );
 }
 
@@ -2561,19 +2617,22 @@ function repositionLabelAwayFromRect(labelRect, overlapRect) {
   const minDistX = (labelRect.width + overlapRect.width) / 2;
   const minDistY = (labelRect.height + overlapRect.height) / 2;
   
-  // Move primarily in the direction with the least overlap
+  // Calculate the overlap amount
   const overlapX = minDistX - Math.abs(labelCenterX - rectCenterX);
   const overlapY = minDistY - Math.abs(labelCenterY - rectCenterY);
   
-  // Add a small buffer to ensure no overlap
-  const buffer = 10;
+  // Add a larger buffer to ensure no overlap
+  const buffer = 20;
+  
+  // Move in the direction with the least overlap, but with a minimum movement
+  const moveDistance = Math.max(Math.min(overlapX, overlapY) + buffer, 30);
   
   if (overlapX < overlapY) {
     // Move horizontally
-    labelRect.x += (overlapX + buffer) * Math.sign(normDirX);
+    labelRect.x += moveDistance * Math.sign(normDirX);
   } else {
     // Move vertically
-    labelRect.y += (overlapY + buffer) * Math.sign(normDirY);
+    labelRect.y += moveDistance * Math.sign(normDirY);
   }
 }
 

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741038837">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741038837">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741043449">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741043449">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -1910,10 +1910,11 @@ function initializeD3Graph() {
 }
 
 function resetZoom() {
-  // Center the graph with an appropriate scale
+  // Center the graph with an appropriate scale for hierarchical layout
+  // In hierarchical layout, we want to center more towards the top where the root node is
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(0, 0).scale(0.5) // More zoomed out to see the entire graph
+    d3.zoomIdentity.translate(0, height * 0.2).scale(0.5) // Shift up slightly to focus on root
   );
 }
 
@@ -1929,10 +1930,22 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Update loading text to show that the graph is being processed
   $('#loading-text').text('Rendering graph visualization...');
   
+  // Add a timeout to ensure loading overlay is hidden even if other mechanisms fail
+  setTimeout(() => {
+    console.log("Timeout check - ensuring loading overlay is hidden");
+    if (document.getElementById('loading')) {
+      document.getElementById('loading').style.display = 'none';
+    }
+    $('#loading-indicator').hide();
+  }, 10000); // 10 seconds should be plenty for the graph to render
+  
   // Initialize container dimensions
   const container = document.getElementById('graph-container');
   width = container.clientWidth;
   height = container.clientHeight;
+  
+  // Make edges available globally to prevent "edges is not defined" errors
+  window.edges = edges;
   
   // Initialize zoom behavior if not already done
   if (!zoom) {
@@ -1973,26 +1986,29 @@ function renderD3Graph(rootSubject, nodes, edges) {
     nodeMap.set(node.id, node);
   });
   
-  // Pre-position nodes in a structured layout
-  // Position root node in the center
+  // Pre-position nodes in a structured layout - critical for avoiding initial overlaps
+  // Position root node at the top center
   if (rootNode) {
-    rootNode.x = 0; // Position at origin (will be transformed to center)
-    rootNode.y = 0; // Position at origin (will be transformed to center)
-    rootNode.fx = 0; // Fix position at origin
-    rootNode.fy = 0; // Fix position at origin
+    rootNode.x = 0; // Center horizontally
+    rootNode.y = -height * 0.35; // Position at top
+    rootNode.fx = 0; // Fix position horizontally
+    rootNode.fy = -height * 0.35; // Fix position vertically
   }
   
-  // Arrange non-root nodes in a circle around the root node at the origin
+  // Arrange non-root nodes in a semi-circle below the root node
   const radius = Math.min(width, height) * 0.25; // Use 25% of the smaller dimension for radius
   nonRootNodes.forEach((node, i) => {
-    const angle = (i * 2 * Math.PI) / nonRootNodes.length;
-    node.x = radius * Math.cos(angle); // Position relative to origin
-    node.y = radius * Math.sin(angle); // Position relative to origin
-    // Don't fix these positions completely, allow force layout to adjust
+    // Use a semi-circle (180 degrees) below the root
+    const angle = (Math.PI * i) / (nonRootNodes.length - 1);
+    node.x = radius * Math.cos(angle); // Position in semi-circle
+    node.y = -height * 0.35 + radius * Math.sin(angle) + radius; // Position below root node
   });
   
   // Preprocess edges to ensure all source and target nodes exist
   console.log(`Processing ${edges.length} edges...`);
+  
+  // Create validEdges variable that references the edges array
+  // This ensures validEdges is defined for any code that references it
   const validEdges = edges.filter(edge => {
     const sourceId = edge.from;
     const targetId = edge.to;
@@ -2019,6 +2035,21 @@ function renderD3Graph(rootSubject, nodes, edges) {
   });
   
   console.log(`Filtered to ${validEdges.length} valid edges`);
+  
+  // Identify first-level nodes (directly connected to root)
+  const firstLevelNodeIds = new Set();
+  validEdges.forEach(edge => {
+    if (edge.from === rootSubject) {
+      firstLevelNodeIds.add(edge.to);
+      console.log(`Added first-level node from root: ${edge.to} via relation: ${edge.label || "unlabeled"}`);
+    } else if (edge.to === rootSubject) {
+      firstLevelNodeIds.add(edge.from);
+      console.log(`Added first-level node to root: ${edge.from} via relation: ${edge.label || "unlabeled"}`);
+    }
+  });
+  
+  console.log(`Identified ${firstLevelNodeIds.size} first-level nodes`);
+  console.log('First-level nodes:', Array.from(firstLevelNodeIds));
   
   // Add arrow markers for links
   const defs = g.append('defs');
@@ -2096,7 +2127,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .on('drag', dragged)
       .on('end', dragEnded)
     );
-    
+   
   // Add rectangles to nodes
   nodeElements.append('rect')
     .attr('rx', 4)
@@ -2199,30 +2230,140 @@ function renderD3Graph(rootSubject, nodes, edges) {
     
   // Add text labels with wrapping
   labelElements.each(function(d) {
-    const labelGroup = d3.select(this);
-    const label = d.label || "";
-    
-    // Skip empty labels
-    if (!label.trim()) {
-      labelGroup.append('text')
-        .attr('class', 'link-label')
-        .attr('fill', '#475569')
-        .text("");
-      return;
+    try {
+      const labelGroup = d3.select(this);
+      const label = d.label || "";
+      
+      // Skip empty labels
+      if (!label.trim()) {
+        labelGroup.append('text')
+          .attr('class', 'link-label')
+          .attr('fill', '#475569')
+          .text("");
+        return;
+      }
+      
+      // Wrap text to max 20 characters per line
+      const wrappedText = wrapText(label, 20);
+      
+      // Add each line of text
+      wrappedText.forEach((line, i) => {
+        labelGroup.append('text')
+          .attr('class', 'link-label')
+          .attr('fill', '#475569')
+          .attr('text-anchor', 'middle') // Center text
+          .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
+          .text(line);
+      });
+      
+      if (!d.pathPoints) {
+        return;
+      }
+      
+      const { source, target } = d.pathPoints;
+      const labelEl = d3.select(this);
+      
+      // Calculate basic position for labels
+      let labelX, labelY;
+      
+      // Create a unique identifier for this edge to ensure consistent offsets
+      const edgeId = `${d.from}-${d.to}`;
+      // Create a hash from the edge ID to get a deterministic but varied offset
+      const hash = Math.abs(edgeId.split('').reduce((a, b) => {
+        a = ((a << 5) - a) + b.charCodeAt(0);
+        return a & a;
+      }, 0));
+      
+      // Get nodes from source and target IDs
+      const sourceNode = nodeMap.get(d.from);
+      const targetNode = nodeMap.get(d.to);
+      
+      // Skip if nodes not found
+      if (!sourceNode || !targetNode) return;
+      
+      // Detect if this is a root connection
+      const isRootConnection = (d.from === rootSubject || d.to === rootSubject);
+      const isFromRoot = d.from === rootSubject;
+      
+      // Calculate the distance between nodes
+      const dx = target.x - source.x;
+      const dy = target.y - source.y;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      
+      // Normalize the direction vector
+      const nx = dx / distance;
+      const ny = dy / distance;
+      
+      // Create perpendicular vector for offset
+      const px = -ny;
+      const py = nx;
+      
+      if (isRootConnection) {
+        // For connections with root
+        const t = isFromRoot ? 0.35 : 0.65; // Position along the path
+        
+        // Calculate base position along the path
+        labelX = source.x + dx * t;
+        labelY = source.y + dy * t;
+        
+        // Apply a perpendicular offset based on hash
+        const perpOffset = 60 + (hash % 40); // 60-100px perpendicular offset
+        labelX += px * perpOffset;
+        labelY += py * perpOffset;
+      } else {
+        // For non-root connections, position at midpoint with perpendicular offset
+        labelX = source.x + dx * 0.5;
+        labelY = source.y + dy * 0.5;
+        
+        // Apply larger perpendicular offset based on hash
+        const perpOffset = 80 + (hash % 60); // 80-140px perpendicular offset
+        
+        // Use a deterministic but varied sign for the offset
+        const sign = ((hash % 2) * 2 - 1); // Either 1 or -1
+        labelX += px * perpOffset * sign;
+        labelY += py * perpOffset * sign;
+      }
+      
+      // Get text elements to calculate size
+      const textElements = labelEl.selectAll('text.link-label');
+      
+      if (textElements.size() > 0) {
+        let labelWidth = 0;
+        let labelHeight = 0;
+        
+        // Calculate total width and height based on all text elements
+        textElements.each(function() {
+          try {
+            const bbox = this.getBBox();
+            labelWidth = Math.max(labelWidth, bbox.width);
+            labelHeight += bbox.height;
+          } catch (e) {
+            console.log("Error getting text bounding box", e);
+          }
+        });
+        
+        // Add more padding
+        labelWidth += 30;
+        labelHeight += 16;
+        
+        // Update background rectangle size
+        labelEl.select('rect.label-bg')
+          .attr('width', labelWidth)
+          .attr('height', labelHeight)
+          .attr('x', -labelWidth / 2)
+          .attr('y', -labelHeight / 2);
+      }
+      
+      // Apply the transform to position the label
+      labelEl.attr('transform', `translate(${labelX}, ${labelY})`);
+      
+      // Store position for collision detection
+      d.labelX = labelX;
+      d.labelY = labelY;
+      
+    } catch (error) {
+      console.error("Error positioning label:", error);
     }
-    
-    // Wrap text to max 20 characters per line
-    const wrappedText = wrapText(label, 20);
-    
-    // Add each line of text
-    wrappedText.forEach((line, i) => {
-      labelGroup.append('text')
-        .attr('class', 'link-label')
-        .attr('fill', '#475569')
-        .attr('text-anchor', 'middle') // Center text
-        .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
-        .text(line);
-    });
   });
   
   // Helper function to highlight a connection between two nodes
@@ -2305,35 +2446,125 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .attr('fill', '#475569');
   }
   
-  // Start the simulation with modified forces for structured layout
+  // First run the simulation without rendering for many iterations
+  // This helps find a better layout before rendering
+  let tempSimulation = d3.forceSimulation(nodes)
+    .force('link', d3.forceLink()
+      .links(edges)
+      .id(d => d.id)
+      .distance(d => {
+        // Vary distance based on connection type
+        if (d.from === rootSubject || d.to === rootSubject) {
+          return 350; // Root connections get even more space
+        }
+        return 250; // More space for other connections
+      }))
+    .force('charge', d3.forceManyBody()
+      .strength(d => d.id === rootSubject ? -2500 : -1500)) // Stronger repulsion
+    .force('x', d3.forceX(d => {
+      if (d.id === rootSubject) return 0;
+      if (firstLevelNodeIds.has(d.id)) {
+        return d.x * 1.7; // Push first level nodes further out horizontally
+      }
+      return d.x;
+    }).strength(0.25))
+    .force('y', d3.forceY(d => {
+      if (d.id === rootSubject) return -height * 0.4;
+      if (firstLevelNodeIds.has(d.id)) {
+        return d.y; // Keep first level at their y positions
+      }
+      return height * 0.35; // Push other nodes down more
+    }).strength(0.25))
+    .force('collision', d3.forceCollide()
+      .radius(d => {
+        // Even larger collision radius to keep nodes well separated
+        const nodeWidth = getNodeWidth(d);
+        const nodeHeight = getNodeHeight(d);
+        
+        if (d.id === rootSubject) {
+          return Math.sqrt(nodeWidth * nodeHeight) + 180;
+        }
+        return Math.sqrt(nodeWidth * nodeHeight) + 130;
+      })
+      .strength(1)) // Full collision strength
+    .stop();
+  
+  // Run the pre-positioning simulation for more iterations
+  for (let i = 0; i < 150; i++) {
+    tempSimulation.tick();
+  }
+  
+  // Now create the actual simulation for rendering
   simulation = d3.forceSimulation(nodes)
     .force('link', d3.forceLink()
-      .links(validEdges)
+      .links(edges)
       .id(d => d.id)
-      .distance(forceParams.linkDistance * 2)) // Double the link distance
+      .distance(d => {
+        // Use different distances for different types of connections
+        if (d.from === rootSubject || d.to === rootSubject) {
+          return forceParams.linkDistance * 10; // More space for root connections
+        }
+        return forceParams.linkDistance * 7; // More space for non-root connections
+      }))
     .force('charge', d3.forceManyBody()
       .strength(d => {
-        // Stronger repulsion for structured layout
+        // Use stronger repulsion for the root
+        if (d.id === rootSubject) {
+          return forceParams.charge * -20;
+        }
+        // Use node size to scale repulsion
         const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
-        return forceParams.charge * (nodeSize / 200) * 2.5; // Significantly increased repulsion
+        return forceParams.charge * (nodeSize / 150) * -15;
       })
-      .distanceMin(400) // Increased minimum distance
-      .distanceMax(5000)) // Increased maximum distance
-    .force('x', d3.forceX(0).strength(0.2)) // Center nodes horizontally at origin
-    .force('y', d3.forceY(0).strength(0.2)) // Center nodes vertically at origin
+      .distanceMin(900)
+      .distanceMax(12000))
+    .force('x', d3.forceX(d => {
+      // Root node stays at center
+      if (d.id === rootSubject) return 0;
+      
+      // First level nodes maintain their existing x position but with scaling
+      if (firstLevelNodeIds.has(d.id)) {
+        return d.x * 1.3; // Expand the first level more
+      }
+      
+      // Second level nodes spread wider
+      return d.x * 1.4;
+    }).strength(d => d.id === rootSubject ? 1 : 0.2))
+    .force('y', d3.forceY(d => {
+      // Keep root at top
+      if (d.id === rootSubject) return -height * 0.4;
+      
+      // First level nodes position
+      if (firstLevelNodeIds.has(d.id)) {
+        return d.y * 0.95; // Keep in their semi-circle but slightly tighter
+      }
+      
+      // Second level nodes position
+      return d.y * 1.3; // Push further down
+    }).strength(d => d.id === rootSubject ? 1 : 0.35))
     .force('collision', d3.forceCollide().radius(d => {
-      // Make collision radius based on node size plus padding
+      // Use much larger collision radius
       const nodeWidth = getNodeWidth(d);
       const nodeHeight = getNodeHeight(d);
-      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 200; // Significantly increased padding
-    }).strength(1))
-    .alpha(0.8) // Higher alpha for more movement
-    .alphaDecay(0.01) // Slower decay for more time to find optimal positions
-    .velocityDecay(0.4)
+      // Different collision radii based on node type
+      if (d.id === rootSubject) {
+        return Math.sqrt(nodeWidth * nodeHeight) + 180;
+      }
+      return Math.sqrt(nodeWidth * nodeHeight) + 130;
+    }).strength(0.95).iterations(4)) // More iterations for better collision resolution
+    .alpha(0.4) // Start with lower alpha since we've pre-positioned
+    .alphaDecay(0.003) // Slower decay for more gradual layout
+    .velocityDecay(0.25) // Adjust velocity decay for smoother movement
     .on('tick', ticked)
     .on('end', () => {
       // When the simulation ends, center the graph based on actual content bounds
       centerGraph();
+      
+      // Failsafe: directly hide loading elements in case centerGraph didn't do it
+      console.log("Simulation ended - ensuring loading overlay is hidden");
+      document.getElementById('loading').style.display = 'none';
+      $('#loading-indicator').hide();
+      $('#loading-overlay').hide();
     });
 }
 
@@ -2342,269 +2573,376 @@ function centerGraph() {
   try {
     // Get the bounding box of the graph content
     const bbox = document.getElementById('graph-content').getBBox();
+    console.log("Graph bbox:", bbox);
     
-    // Calculate the center of the graph content
+    // Calculate the dimensions of the viewport
+    const viewportWidth = width;
+    const viewportHeight = height;
+    console.log("Viewport dimensions:", viewportWidth, viewportHeight);
+    
+    // Calculate the center of the graph content with emphasis on the root node
+    // For knowledge graphs, we want the root higher in the viewport
     const graphCenterX = bbox.x + bbox.width / 2;
-    const graphCenterY = bbox.y + bbox.height / 2;
+    const graphCenterY = bbox.y + bbox.height * 0.35; // 35% point to shift focus upward
     
     // Calculate the translation needed to center the graph
-    const translateX = width / 2 - graphCenterX;
-    const translateY = height / 2 - graphCenterY;
+    const translateX = viewportWidth / 2 - graphCenterX;
+    const translateY = viewportHeight / 2 - graphCenterY;
+    console.log("Translation:", translateX, translateY);
     
-    // Update the zoom transform to center the graph
-    d3.select('#graph').call(
-      zoom.transform,
-      d3.zoomIdentity.translate(translateX, translateY).scale(0.5)
+    // Determine appropriate initial scale based on the graph size
+    // We want to fit the graph with some margin
+    let initialScale = Math.min(
+      viewportWidth / (bbox.width * 1.25),  // 25% margin horizontally
+      viewportHeight / (bbox.height * 1.25) // 25% margin vertically
     );
     
-    console.log('Graph centered based on actual bounds:', { 
-      bbox, 
-      graphCenter: { x: graphCenterX, y: graphCenterY },
-      translation: { x: translateX, y: translateY }
-    });
+    // Limit scale to reasonable bounds
+    initialScale = Math.min(Math.max(initialScale, 0.15), 0.75);
+    console.log("Initial scale:", initialScale);
     
-    // Hide the loading overlay when the graph is fully loaded and centered
-    const loadingEl = document.getElementById('loading');
-    if (loadingEl) {
-      loadingEl.style.opacity = '0';
-      loadingEl.style.transition = 'opacity 0.3s ease-out';
-      setTimeout(() => {
-        loadingEl.style.display = 'none';
-      }, 300);
-    }
+    // Update the zoom transform to center the graph with appropriate scale
+    d3.select('#graph').call(
+      zoom.transform,
+      d3.zoomIdentity
+        .translate(translateX, translateY)
+        .scale(initialScale)
+    );
+    
+    // Hide loading overlay and indicators
+    document.getElementById('loading').style.display = 'none';
+    $('#loading-indicator').hide();
+    $('#loading-overlay').fadeOut();
+    
+    console.log("Loading overlay hidden");
   } catch (error) {
-    console.error('Error centering graph:', error);
+    console.error("Error centering graph:", error);
   }
 }
 
-// Update the ticked function to properly position nodes, links, and labels
+// Function for updating element positions on tick
 function ticked() {
   try {
-    // Update node positions
-    nodeElements.attr('transform', d => {
-      // Constrain to bounds relative to origin
-      const halfWidth = width / 2;
-      const halfHeight = height / 2;
-      d.x = Math.max(-halfWidth + 50, Math.min(halfWidth - 50, d.x));
-      d.y = Math.max(-halfHeight + 50, Math.min(halfHeight - 50, d.y));
-      return `translate(${d.x - getNodeWidth(d) / 2}, ${d.y - getNodeHeight(d) / 2})`;
+    // Keep the root node fixed at the top
+    simulation.nodes().forEach(d => {
+      if (d.id === rootSubject) {
+        d.x = 0;
+        d.y = -height * 0.4;
+        d.fx = 0;
+        d.fy = -height * 0.4;
+      }
     });
     
-    // Update link paths with improved orthogonal routing
-    linkElements.attr('d', d => {
+    // Get the bounds of the available canvas area
+    const graphWidth = width * 2;  // Make the bounding box larger than the visible area
+    const graphHeight = height * 2;
+    
+    // Add border constraints - keep nodes within bounds
+    simulation.nodes().forEach(function(d) {
+      // Don't apply to fixed nodes (like the root)
+      if (d.fx !== undefined || d.fy !== undefined) return;
+      
+      // Don't let nodes go too far off-canvas
+      const nodeWidth = getNodeWidth(d);
+      const nodeHeight = getNodeHeight(d);
+      
+      // Softer constraints - gradually increase force as nodes approach edges
+      const margin = 200; // Increased margin
+      
+      // X bounds
+      const xMin = -graphWidth/2 + nodeWidth/2 + margin;
+      const xMax = graphWidth/2 - nodeWidth/2 - margin;
+      
+      // Y bounds - allow more space at the top for the hierarchical layout
+      const yMin = -graphHeight/2 + nodeHeight/2 + margin;
+      const yMax = graphHeight/2 - nodeHeight/2 - margin;
+      
+      if (d.x < xMin) {
+        d.x = xMin + (d.x - xMin) * 0.1; // gradual enforcement
+        d.vx = Math.abs(d.vx) * 0.5; // dampen velocity and reverse direction
+      }
+      if (d.x > xMax) {
+        d.x = xMax - (xMax - d.x) * 0.1; // gradual enforcement
+        d.vx = -Math.abs(d.vx) * 0.5; // dampen velocity and reverse direction
+      }
+      
+      if (d.y < yMin) {
+        d.y = yMin + (d.y - yMin) * 0.1; // gradual enforcement
+        d.vy = Math.abs(d.vy) * 0.5; // dampen velocity and reverse direction
+      }
+      if (d.y > yMax) {
+        d.y = yMax - (yMax - d.y) * 0.1; // gradual enforcement
+        d.vy = -Math.abs(d.vy) * 0.5; // dampen velocity and reverse direction
+      }
+    });
+    
+    // Update node positions
+    nodeElements.attr('transform', d => `translate(${d.x - getNodeWidth(d) / 2},${d.y - getNodeHeight(d) / 2})`);
+    
+    // Helper function to get node layer for path generation
+    function getNodeLayer(nodeId, edgesList) {
+      // Root is always layer 0
+      if (nodeId === rootSubject) return 0;
+      
+      // First level: directly connected to root
+      const isConnectedToRoot = edgesList.some(e => 
+        (e.from === rootSubject && e.to === nodeId) || 
+        (e.to === rootSubject && e.from === nodeId)
+      );
+      
+      if (isConnectedToRoot) return 1;
+      
+      // Otherwise it's a deeper level
+      return 2;
+    }
+    
+    // Update link positions with more advanced path generation
+    linkElements.attr('d', function(d) {
       try {
-        // Get source and target IDs
         const sourceId = d.from;
         const targetId = d.to;
         
-        if (!sourceId || !targetId) {
-          console.warn("Missing source or target ID in link path calculation:", d);
-          return '';
-        }
-        
-        // Get the actual node objects using the nodeMap
+        // Get source and target nodes from the ID
         const sourceNode = nodeMap.get(sourceId);
         const targetNode = nodeMap.get(targetId);
         
         if (!sourceNode || !targetNode) {
-          console.warn("Missing node for link in ticked:", 
-                      !sourceNode ? `source: ${sourceId}` : `target: ${targetId}`);
+          console.warn(`Missing node data for ${sourceId} or ${targetId}`);
           return '';
         }
         
-        // Calculate dimensions
-        const sourceWidth = getNodeWidth(sourceNode);
-        const sourceHeight = getNodeHeight(sourceNode);
-        const targetWidth = getNodeWidth(targetNode);
-        const targetHeight = getNodeHeight(targetNode);
+        // Calculate source and target points
+        const sourcePoint = {
+          x: sourceNode.x,
+          y: sourceNode.y
+        };
         
-        // Calculate source and target centers
-        const sourceX = sourceNode.x;
-        const sourceY = sourceNode.y;
-        const targetX = targetNode.x;
-        const targetY = targetNode.y;
+        const targetPoint = {
+          x: targetNode.x,
+          y: targetNode.y
+        };
         
-        // Find intersection points with rectangles
-        const sourcePoint = findIntersectionPoint(
-          sourceX, sourceY, targetX, targetY,
-          sourceX - sourceWidth/2, sourceY - sourceHeight/2,
-          sourceWidth, sourceHeight
-        );
-        
-        const targetPoint = findIntersectionPoint(
-          targetX, targetY, sourceX, sourceY,
-          targetX - targetWidth/2, targetY - targetHeight/2,
-          targetWidth, targetHeight
-        );
-        
-        if (!sourcePoint || !targetPoint) {
-          console.warn("Could not find intersection points for link:", sourceId, targetId);
-          // Fallback to direct line between centers
+        // Direct line for debugging
+        if (window.debugMode) {
+          const sourceX = sourceNode.x;
+          const sourceY = sourceNode.y;
+          const targetX = targetNode.x;
+          const targetY = targetNode.y;
           return `M${sourceX},${sourceY} L${targetX},${targetY}`;
         }
         
-        // Create orthogonal (right-angled) paths with better routing
-        // Calculate if nodes are more horizontal or vertical to each other
-        const dx = Math.abs(targetPoint.x - sourcePoint.x);
-        const dy = Math.abs(targetPoint.y - sourcePoint.y);
-        const isHorizontal = dx > dy;
+        // Adjust path drawing based on whether this is a connection from/to root
+        const isRootConnection = (sourceId === rootSubject || targetId === rootSubject);
+        const isSourceHigher = sourcePoint.y < targetPoint.y;
         
-        // Create path with more segments to avoid running behind nodes
+        // Create path with more segments for hierarchical flow
         let path = '';
         
-        // Remove the offset to ensure lines connect directly to nodes without gaps
-        const arrowOffset = 0;
-        
-        // Adjust target point to account for arrow - no offset to avoid gaps
+        // Adjust target point to account for arrow
         const targetPointWithOffset = {
           x: targetPoint.x,
           y: targetPoint.y
         };
-        
-        if (isHorizontal) {
-          // For horizontal arrangement, use 3 segments with vertical middle segment
-          const midX = (sourcePoint.x + targetPointWithOffset.x) / 2;
-          path = `M${sourcePoint.x},${sourcePoint.y} 
-                  L${midX},${sourcePoint.y} 
-                  L${midX},${targetPointWithOffset.y} 
-                  L${targetPointWithOffset.x},${targetPointWithOffset.y}`;
+
+        // For hierarchical layout, use different path strategies
+        if (isRootConnection) {
+          // For connections involving the root, use more direct paths
+          if (sourceId === rootSubject) {
+            // Root to other nodes - create more spread out curves
+            const controlDistance = Math.abs(targetPoint.x - sourcePoint.x) * 0.5;
+            const midY = sourcePoint.y + (targetPoint.y - sourcePoint.y) * 0.4;
+            
+            // Use bezier curves with control points that spread out more
+            path = `M${sourcePoint.x},${sourcePoint.y} 
+                    C${sourcePoint.x},${sourcePoint.y + controlDistance} 
+                    ${targetPoint.x},${targetPoint.y - controlDistance} 
+                    ${targetPoint.x},${targetPoint.y}`;
+          } else {
+            // Other nodes to root - create more spread out curves going upward
+            const controlDistance = Math.abs(sourcePoint.x - targetPoint.x) * 0.5;
+            
+            // Use bezier curves with control points that spread out more
+            path = `M${sourcePoint.x},${sourcePoint.y} 
+                    C${sourcePoint.x},${sourcePoint.y - controlDistance} 
+                    ${targetPoint.x},${targetPoint.y + controlDistance} 
+                    ${targetPoint.x},${targetPoint.y}`;
+          }
         } else {
-          // For vertical arrangement, use 3 segments with horizontal middle segment
-          const midY = (sourcePoint.y + targetPointWithOffset.y) / 2;
-          path = `M${sourcePoint.x},${sourcePoint.y} 
-                  L${sourcePoint.x},${midY} 
-                  L${targetPointWithOffset.x},${midY} 
-                  L${targetPointWithOffset.x},${targetPointWithOffset.y}`;
+          // For connections between non-root nodes
+          // Calculate the "layer" of the node based on its position
+          const sourceLayer = getNodeLayer(sourceId, edges);
+          const targetLayer = getNodeLayer(targetId, edges);
+          
+          // Route differently based on whether nodes are on same layer or different layers
+          if (Math.abs(sourcePoint.y - targetPoint.y) > Math.abs(sourcePoint.x - targetPoint.x) * 1.2) {
+            // More vertical than horizontal - likely across layers
+            // Use S-curves for more separation between paths
+            const dx = targetPoint.x - sourcePoint.x;
+            const dy = targetPoint.y - sourcePoint.y;
+            
+            // Calculate offset based on the uniqueness of the connection
+            const connectionId = sourceId.length + targetId.length + sourcePoint.x;
+            const randomOffset = (connectionId % 100) / 100 * 0.4 + 0.3; // 0.3 to 0.7 range
+            
+            // Create control points for S-curve
+            const cp1x = sourcePoint.x + dx * 0.1;
+            const cp1y = sourcePoint.y + dy * randomOffset;
+            const cp2x = sourcePoint.x + dx * 0.9;
+            const cp2y = sourcePoint.y + dy * (1 - randomOffset);
+            
+            path = `M${sourcePoint.x},${sourcePoint.y} 
+                    C${cp1x},${cp1y} ${cp2x},${cp2y} ${targetPoint.x},${targetPoint.y}`;
+          } else if (Math.abs(sourceLayer - targetLayer) <= 1) {
+            // Nodes are on similar layers - use a curved path
+            const midX = (sourcePoint.x + targetPoint.x) / 2;
+            // Add some randomness to midY to reduce overlaps
+            const midYOffset = (sourceId.length + targetId.length) % 100;
+            const midY = (sourcePoint.y + targetPoint.y) / 2 + (midYOffset - 50);
+            
+            path = `M${sourcePoint.x},${sourcePoint.y} 
+                    Q${midX},${midY} ${targetPoint.x},${targetPoint.y}`;
+          } else {
+            // Significant horizontal distance - use orthogonal routing with randomized midpoints
+            const midX = (sourcePoint.x + targetPoint.x) / 2 + 
+                      ((sourceId.length * targetId.length) % 100 - 50);
+            const yDiff = Math.abs(targetPoint.y - sourcePoint.y);
+            const midY1 = sourcePoint.y + (isSourceHigher ? yDiff * 0.25 : -yDiff * 0.25);
+            const midY2 = targetPoint.y + (isSourceHigher ? -yDiff * 0.25 : yDiff * 0.25);
+            
+            path = `M${sourcePoint.x},${sourcePoint.y} 
+                    C${sourcePoint.x},${midY1} ${midX},${midY1} ${midX},${(midY1 + midY2) / 2}
+                    S${targetPoint.x},${midY2} ${targetPoint.x},${targetPoint.y}`;
+          }
         }
         
         // Store the path points for label positioning
         d.pathPoints = {
           source: sourcePoint,
           target: targetPointWithOffset,
-          isHorizontal: isHorizontal
+          isHorizontal: Math.abs(sourcePoint.x - targetPoint.x) > Math.abs(sourcePoint.y - targetPoint.y)
         };
         
         return path;
       } catch (error) {
-        console.error("Error in link path calculation:", error, d);
+        console.error("Error generating link path:", error);
         return '';
       }
     });
     
-    // Update label positions
+    // Update label positions on the links
     labelElements.each(function(d) {
       try {
-        const labelGroup = d3.select(this);
-        
-        // Get source and target IDs
-        const sourceId = d.from;
-        const targetId = d.to;
-        
-        if (!sourceId || !targetId) {
-          console.warn("Missing source or target ID in label positioning");
+        if (!d.pathPoints) {
           return;
         }
         
-        // Find the path element for this edge
-        const path = d3.select(`path.link[data-source="${sourceId}"][data-target="${targetId}"]`).node();
+        const { source, target } = d.pathPoints;
+        const labelEl = d3.select(this);
         
-        let midX, midY;
+        // Calculate basic position for labels
+        let labelX, labelY;
         
-        // If we have a path, position the label at its midpoint
-        if (path) {
-          const pathLength = path.getTotalLength();
-          if (pathLength) {
-            // Store the path for later use in overlap prevention
-            d.path = path;
-            
-            // Get the midpoint of the path
-            const midPoint = path.getPointAtLength(pathLength / 2);
-            midX = midPoint.x;
-            midY = midPoint.y;
-            
-            // If we have stored path points, use them for better label positioning
-            if (d.pathPoints) {
-              const { source, target, isHorizontal } = d.pathPoints;
-              
-              if (isHorizontal) {
-                // For horizontal paths, position label above or below the middle segment
-                const midX = (source.x + target.x) / 2;
-                midY = source.y + (target.y - source.y) / 2;
-                
-                // Increase offset to avoid overlap
-                midY += (source.y > target.y) ? -40 : 40;
-              } else {
-                // For vertical paths, position label to the left or right of the middle segment
-                midX = source.x + (target.x - source.x) / 2;
-                const midY = (source.y + target.y) / 2;
-                
-                // Increase offset to avoid overlap
-                midX += (source.x > target.x) ? -40 : 40;
-              }
-            }
-          } else {
-            // Fallback if path length is 0
-            const sourceNode = nodeMap.get(sourceId);
-            const targetNode = nodeMap.get(targetId);
-            
-            if (!sourceNode || !targetNode) {
-              console.warn("Missing node in label positioning fallback");
-              return;
-            }
-            
-            midX = (sourceNode.x + targetNode.x) / 2;
-            midY = (sourceNode.y + targetNode.y) / 2;
-          }
+        // Create a unique identifier for this edge to ensure consistent offsets
+        const edgeId = `${d.from}-${d.to}`;
+        // Create a hash from the edge ID to get a deterministic but varied offset
+        const hash = Math.abs(edgeId.split('').reduce((a, b) => {
+          a = ((a << 5) - a) + b.charCodeAt(0);
+          return a & a;
+        }, 0));
+        
+        // Get nodes from source and target IDs
+        const sourceNode = nodeMap.get(d.from);
+        const targetNode = nodeMap.get(d.to);
+        
+        // Skip if nodes not found
+        if (!sourceNode || !targetNode) return;
+        
+        // Detect if this is a root connection
+        const isRootConnection = (d.from === rootSubject || d.to === rootSubject);
+        const isFromRoot = d.from === rootSubject;
+        
+        // Calculate the distance between nodes
+        const dx = target.x - source.x;
+        const dy = target.y - source.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        
+        // Normalize the direction vector
+        const nx = dx / distance;
+        const ny = dy / distance;
+        
+        // Create perpendicular vector for offset
+        const px = -ny;
+        const py = nx;
+        
+        if (isRootConnection) {
+          // For connections with root
+          const t = isFromRoot ? 0.35 : 0.65; // Position along the path
+          
+          // Calculate base position along the path
+          labelX = source.x + dx * t;
+          labelY = source.y + dy * t;
+          
+          // Apply a perpendicular offset based on hash
+          const perpOffset = 60 + (hash % 40); // 60-100px perpendicular offset
+          labelX += px * perpOffset;
+          labelY += py * perpOffset;
         } else {
-          // Fallback: position between nodes if no path is found
-          const sourceNode = nodeMap.get(sourceId);
-          const targetNode = nodeMap.get(targetId);
+          // For non-root connections, position at midpoint with perpendicular offset
+          labelX = source.x + dx * 0.5;
+          labelY = source.y + dy * 0.5;
           
-          if (!sourceNode || !targetNode) {
-            console.warn("Missing node in label positioning fallback");
-            return;
-          }
+          // Apply larger perpendicular offset based on hash
+          const perpOffset = 80 + (hash % 60); // 80-140px perpendicular offset
           
-          midX = (sourceNode.x + targetNode.x) / 2;
-          midY = (sourceNode.y + targetNode.y) / 2;
+          // Use a deterministic but varied sign for the offset
+          const sign = ((hash % 2) * 2 - 1); // Either 1 or -1
+          labelX += px * perpOffset * sign;
+          labelY += py * perpOffset * sign;
         }
         
-        // Store label position for overlap prevention
-        d.labelX = midX;
-        d.labelY = midY;
+        // Get text elements to calculate size
+        const textElements = labelEl.selectAll('text.link-label');
         
-        // Update transform
-        labelGroup.attr('transform', `translate(${midX}, ${midY})`);
+        if (textElements.size() > 0) {
+          let labelWidth = 0;
+          let labelHeight = 0;
+          
+          // Calculate total width and height based on all text elements
+          textElements.each(function() {
+            try {
+              const bbox = this.getBBox();
+              labelWidth = Math.max(labelWidth, bbox.width);
+              labelHeight += bbox.height;
+            } catch (e) {
+              console.log("Error getting text bounding box", e);
+            }
+          });
+          
+          // Add more padding
+          labelWidth += 30;
+          labelHeight += 16;
+          
+          // Update background rectangle size
+          labelEl.select('rect.label-bg')
+            .attr('width', labelWidth)
+            .attr('height', labelHeight)
+            .attr('x', -labelWidth / 2)
+            .attr('y', -labelHeight / 2);
+        }
         
-        // Size the background rectangle based on the text content
-        const textElements = labelGroup.selectAll('.link-label');
-        let maxWidth = 0;
-        let totalHeight = 0;
+        // Apply the transform to position the label
+        labelEl.attr('transform', `translate(${labelX}, ${labelY})`);
         
-        textElements.each(function() {
-          const bbox = this.getBBox();
-          maxWidth = Math.max(maxWidth, bbox.width);
-          totalHeight += bbox.height;
-        });
+        // Store position for collision detection
+        d.labelX = labelX;
+        d.labelY = labelY;
         
-        // Add padding to the background rectangle
-        const padding = 8;
-        
-        // Update background rectangle size with padding
-        labelGroup.select('.label-bg')
-          .attr('width', maxWidth + padding * 2)
-          .attr('height', totalHeight + padding * 2)
-          .attr('x', -maxWidth / 2 - padding)
-          .attr('y', -totalHeight / 2 - padding);
       } catch (error) {
-        console.error("Error in label positioning:", error, d);
+        console.error("Error positioning label:", error);
       }
     });
-    
-    // Run label overlap prevention
-    preventLabelOverlaps();
   } catch (error) {
-    console.error("Error in ticked function:", error);
+    console.error("Error in tick function:", error);
   }
 }
 
@@ -3095,6 +3433,43 @@ function buildGraph(subject, filterKeywords = []) {
   // Start fetch process
   const relationsZip = `../data/${subject}.zip`;
   // ... existing code ...
+}
+
+// Helper function to determine the "layer" of a node based on distance from root
+function getNodeLayer(nodeId, edgesParam) {
+  // Use provided edges parameter or fall back to global edges
+  const edgesToUse = edgesParam || window.edges;
+  
+  if (nodeId === rootSubject) {
+    return 0; // Root node is layer 0
+  }
+  
+  // Check if directly connected to root
+  const isDirectlyConnected = edgesToUse.some(
+    edge => (edge.from === rootSubject && edge.to === nodeId) || 
+            (edge.to === rootSubject && edge.from === nodeId)
+  );
+  
+  if (isDirectlyConnected) {
+    return 1; // Directly connected to root is layer 1
+  }
+  
+  // Get nodes directly connected to root
+  const connectedToRoot = edgesToUse.filter(
+    edge => edge.from === rootSubject || edge.to === rootSubject
+  ).map(edge => edge.from === rootSubject ? edge.to : edge.from);
+  
+  // Check if connected to a node that's connected to root
+  const isTwoStepsAway = edgesToUse.some(
+    edge => (connectedToRoot.includes(edge.from) && edge.to === nodeId) || 
+            (connectedToRoot.includes(edge.to) && edge.from === nodeId)
+  );
+  
+  if (isTwoStepsAway) {
+    return 2; // Two steps away from root is layer 2
+  }
+  
+  return 3; // Everything else is layer 3 or beyond
 }
 </script>
 </body>

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741045436">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741045436">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741045845">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741045845">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -2213,10 +2213,20 @@ function renderD3Graph(rootSubject, nodes, edges) {
       
       // Highlight this connection
       highlightConnection(d.from, d.to);
+      
+      // Highlight the specific path
+      linkElements.filter(l => l.from === d.from && l.to === d.to)
+        .attr('stroke-width', 4)
+        .attr('stroke-opacity', 1);
     })
-    .on('mouseout', function() {
+    .on('mouseout', function(event, d) {
       console.log('Label bg mouseout');
       resetHighlights();
+      
+      // Restore original path styling
+      linkElements.filter(l => l.from === d.from && l.to === d.to)
+        .attr('stroke-width', 2)
+        .attr('stroke-opacity', 0.8);
     });
     
   // Add text labels with wrapping
@@ -2234,18 +2244,34 @@ function renderD3Graph(rootSubject, nodes, edges) {
         return;
       }
       
-      // Wrap text to max 20 characters per line
-      const wrappedText = wrapText(label, 20);
+      // For "Son of" relationship, use special styling and don't wrap
+      const isSonOfRelation = label.includes("Son of") || label.includes("Child of") || 
+                             label.includes("Parent of") || label.includes("Father of") || 
+                             label.includes("Mother of");
       
-      // Add each line of text
-      wrappedText.forEach((line, i) => {
+      if (isSonOfRelation) {
+        // Use a single text element with special styling for these important relationships
         labelGroup.append('text')
-          .attr('class', 'link-label')
-          .attr('fill', '#475569')
-          .attr('text-anchor', 'middle') // Center text
-          .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
-          .text(line);
-      });
+          .attr('class', 'link-label relationship-label')
+          .attr('fill', '#3B82F6') // Blue color for relationship labels
+          .attr('text-anchor', 'middle')
+          .attr('font-weight', 'bold')
+          .attr('dy', '0.3em')
+          .text(label);
+      } else {
+        // Wrap text to max 20 characters per line for other relationships
+        const wrappedText = wrapText(label, 20);
+        
+        // Add each line of text
+        wrappedText.forEach((line, i) => {
+          labelGroup.append('text')
+            .attr('class', 'link-label')
+            .attr('fill', '#475569')
+            .attr('text-anchor', 'middle') // Center text
+            .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
+            .text(line);
+        });
+      }
       
       if (!d.pathPoints) {
         return;
@@ -2343,15 +2369,14 @@ function renderD3Graph(rootSubject, nodes, edges) {
           .attr('height', labelHeight)
           .attr('x', -labelWidth / 2)
           .attr('y', -labelHeight / 2);
+        
+        // Update the text position to match the background
+        labelEl.attr('transform', `translate(${labelX},${labelY})`);
+        
+        // Store the position for use in interactions
+        d.labelX = labelX;
+        d.labelY = labelY;
       }
-      
-      // Apply the transform to position the label
-      labelEl.attr('transform', `translate(${labelX}, ${labelY})`);
-      
-      // Store position for collision detection
-      d.labelX = labelX;
-      d.labelY = labelY;
-      
     } catch (error) {
       console.error("Error positioning label:", error);
     }
@@ -2833,6 +2858,9 @@ function ticked() {
           y: targetNode.y
         };
         
+        // Store the source and target points for label positioning
+        d.pathPoints = { source: sourcePoint, target: targetPoint };
+        
         // Direct line for debugging
         if (window.debugMode) {
           const sourceX = sourceNode.x;
@@ -2844,23 +2872,50 @@ function ticked() {
         
         // Adjust path drawing based on whether this is a connection from/to root
         const isRootConnection = (sourceId === rootSubject || targetId === rootSubject);
-        const isSourceHigher = sourcePoint.y < targetPoint.y;
+        
+        // Check if this is a "Son of" relationship
+        const isSonOfRelation = d.label && (d.label.includes("Son of") || d.label.includes("Child of") || d.label.includes("Parent of") || d.label.includes("Father of") || d.label.includes("Mother of"));
         
         // Create path with more segments for hierarchical flow
         let path = '';
         
-        // Adjust target point to account for arrow
-        const targetPointWithOffset = {
-          x: targetPoint.x,
-          y: targetPoint.y
-        };
-
+        // For "Son of" relations, use a more prominent curve
+        if (isSonOfRelation) {
+          // Calculate midpoint with offset for a nice curve
+          const midX = (sourcePoint.x + targetPoint.x) / 2;
+          const midY = (sourcePoint.y + targetPoint.y) / 2;
+          
+          // Calculate a perpendicular vector to the line
+          const dx = targetPoint.x - sourcePoint.x;
+          const dy = targetPoint.y - sourcePoint.y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          
+          // Normalize and get perpendicular vector
+          const nx = dx / dist;
+          const ny = dy / dist;
+          const px = -ny;
+          const py = nx;
+          
+          // Create a large curve for "Son of" relationships
+          // The curve should extend away from the direct line to make space for the label
+          const curveOffset = dist * 0.3; // 30% of distance as curve height
+          
+          // Apply the curve offset
+          const ctrlX = midX + px * curveOffset;
+          const ctrlY = midY + py * curveOffset;
+          
+          // Use a quadratic curve for "Son of" relationships
+          path = `M${sourcePoint.x},${sourcePoint.y} Q${ctrlX},${ctrlY} ${targetPoint.x},${targetPoint.y}`;
+          
+          // Store control points for label positioning
+          d.curveControlPoints = { ctrlX, ctrlY };
+        }
         // For hierarchical layout, use different path strategies
-        if (isRootConnection) {
+        else if (isRootConnection) {
           // For connections involving the root, use more direct paths
           if (sourceId === rootSubject) {
             // Root to other nodes - create more spread out curves
-            const controlDistance = Math.abs(targetPoint.x - sourcePoint.x) * 0.5;
+            const controlDistance = Math.abs(targetPoint.x - sourcePoint.x) * 0.3;
             const midY = sourcePoint.y + (targetPoint.y - sourcePoint.y) * 0.4;
             
             // Use bezier curves with control points that spread out more
@@ -2868,15 +2923,31 @@ function ticked() {
                     C${sourcePoint.x},${sourcePoint.y + controlDistance} 
                     ${targetPoint.x},${targetPoint.y - controlDistance} 
                     ${targetPoint.x},${targetPoint.y}`;
+            
+            // Store control points for label positioning
+            d.curveControlPoints = { 
+              ctrl1X: sourcePoint.x, 
+              ctrl1Y: sourcePoint.y + controlDistance,
+              ctrl2X: targetPoint.x, 
+              ctrl2Y: targetPoint.y - controlDistance 
+            };
           } else {
             // Other nodes to root - create more spread out curves going upward
-            const controlDistance = Math.abs(sourcePoint.x - targetPoint.x) * 0.5;
+            const controlDistance = Math.abs(sourcePoint.x - targetPoint.x) * 0.3;
             
             // Use bezier curves with control points that spread out more
             path = `M${sourcePoint.x},${sourcePoint.y} 
                     C${sourcePoint.x},${sourcePoint.y - controlDistance} 
                     ${targetPoint.x},${targetPoint.y + controlDistance} 
                     ${targetPoint.x},${targetPoint.y}`;
+            
+            // Store control points for label positioning
+            d.curveControlPoints = { 
+              ctrl1X: sourcePoint.x, 
+              ctrl1Y: sourcePoint.y - controlDistance,
+              ctrl2X: targetPoint.x, 
+              ctrl2Y: targetPoint.y + controlDistance 
+            };
           }
         } else {
           // For connections between non-root nodes
@@ -2929,7 +3000,7 @@ function ticked() {
         // Store the path points for label positioning
         d.pathPoints = {
           source: sourcePoint,
-          target: targetPointWithOffset,
+          target: targetPoint,
           isHorizontal: Math.abs(sourcePoint.x - targetPoint.x) > Math.abs(sourcePoint.y - targetPoint.y)
         };
         
@@ -2949,17 +3020,6 @@ function ticked() {
         
         const { source, target } = d.pathPoints;
         const labelEl = d3.select(this);
-        
-        // Calculate basic position for labels
-        let labelX, labelY;
-        
-        // Create a unique identifier for this edge to ensure consistent offsets
-        const edgeId = `${d.from}-${d.to}`;
-        // Create a hash from the edge ID to get a deterministic but varied offset
-        const hash = Math.abs(edgeId.split('').reduce((a, b) => {
-          a = ((a << 5) - a) + b.charCodeAt(0);
-          return a & a;
-        }, 0));
         
         // Get nodes from source and target IDs
         const sourceNode = nodeMap.get(d.from);
@@ -2985,30 +3045,77 @@ function ticked() {
         const px = -ny;
         const py = nx;
         
-        if (isRootConnection) {
-          // For connections with root
-          const t = isFromRoot ? 0.35 : 0.65; // Position along the path
-          
-          // Calculate base position along the path
-          labelX = source.x + dx * t;
-          labelY = source.y + dy * t;
-          
-          // Apply a perpendicular offset based on hash
-          const perpOffset = 60 + (hash % 40); // 60-100px perpendicular offset
-          labelX += px * perpOffset;
-          labelY += py * perpOffset;
+        // Get actual path element for this edge to find points along the path
+        const pathElement = linkElements.filter(e => e.from === d.from && e.to === d.to).node();
+        let labelX, labelY;
+        
+        if (pathElement) {
+          try {
+            // Get the total length of the path
+            const pathLength = pathElement.getTotalLength();
+            
+            // Position the label at a specific point along the path
+            // Root connections might need different positioning
+            let pathPosition;
+            
+            if (isRootConnection) {
+              pathPosition = isFromRoot ? 0.4 : 0.6; // Position along the path
+            } else {
+              pathPosition = 0.5; // Middle of the path for non-root connections
+            }
+            
+            // Get the point at the desired position along the path
+            const point = pathElement.getPointAtLength(pathLength * pathPosition);
+            labelX = point.x;
+            labelY = point.y;
+            
+            // Create a unique identifier for this edge to ensure consistent offsets
+            const edgeId = `${d.from}-${d.to}`;
+            // Create a hash from the edge ID to get a deterministic but varied offset
+            const hash = Math.abs(edgeId.split('').reduce((a, b) => {
+              a = ((a << 5) - a) + b.charCodeAt(0);
+              return a & a;
+            }, 0));
+            
+            // For curves, we might need to adjust the perpendicular offset
+            // Get points slightly before and after the current point to determine the tangent
+            const pointBefore = pathElement.getPointAtLength(Math.max(0, pathLength * pathPosition - 10));
+            const pointAfter = pathElement.getPointAtLength(Math.min(pathLength, pathLength * pathPosition + 10));
+            
+            // Calculate the tangent vector at this point
+            const tangentX = pointAfter.x - pointBefore.x;
+            const tangentY = pointAfter.y - pointBefore.y;
+            const tangentLength = Math.sqrt(tangentX * tangentX + tangentY * tangentY);
+            
+            // Normalize the tangent vector
+            const tnx = tangentX / tangentLength;
+            const tny = tangentY / tangentLength;
+            
+            // Calculate the perpendicular vector to the tangent
+            const tpx = -tny;
+            const tpy = tnx;
+            
+            // Apply a small perpendicular offset to ensure text is on the line but visible
+            const perpOffset = 15 + (hash % 10); // Smaller offset - just enough to not overlap the line
+            
+            // Use a deterministic but varied sign for the offset
+            const sign = ((hash % 2) * 2 - 1); // Either 1 or -1
+            labelX += tpx * perpOffset * sign;
+            labelY += tpy * perpOffset * sign;
+          } catch (e) {
+            console.warn("Error positioning label on path:", e);
+            
+            // Fallback to simple midpoint positioning
+            labelX = source.x + dx * 0.5;
+            labelY = source.y + dy * 0.5;
+          }
         } else {
-          // For non-root connections, position at midpoint with perpendicular offset
+          // Fallback if path element not found
+          console.warn("Path element not found for label positioning");
+          
+          // Position at midpoint with offset
           labelX = source.x + dx * 0.5;
           labelY = source.y + dy * 0.5;
-          
-          // Apply larger perpendicular offset based on hash
-          const perpOffset = 80 + (hash % 60); // 80-140px perpendicular offset
-          
-          // Use a deterministic but varied sign for the offset
-          const sign = ((hash % 2) * 2 - 1); // Either 1 or -1
-          labelX += px * perpOffset * sign;
-          labelY += py * perpOffset * sign;
         }
         
         // Get text elements to calculate size
@@ -3039,15 +3146,14 @@ function ticked() {
             .attr('height', labelHeight)
             .attr('x', -labelWidth / 2)
             .attr('y', -labelHeight / 2);
+          
+          // Update the text position to match the background
+          labelEl.attr('transform', `translate(${labelX},${labelY})`);
+          
+          // Store the position for use in interactions
+          d.labelX = labelX;
+          d.labelY = labelY;
         }
-        
-        // Apply the transform to position the label
-        labelEl.attr('transform', `translate(${labelX}, ${labelY})`);
-        
-        // Store position for collision detection
-        d.labelX = labelX;
-        d.labelY = labelY;
-        
       } catch (error) {
         console.error("Error positioning label:", error);
       }
@@ -3582,6 +3688,25 @@ function getNodeLayer(nodeId, edgesParam) {
   
   return 3; // Everything else is layer 3 or beyond
 }
+
+// Add text to labels
+labelElements.append('text')
+  .attr('class', 'link-label')
+  .attr('text-anchor', 'middle')
+  .attr('dominant-baseline', 'middle')
+  .attr('fill', '#374151')
+  .style('pointer-events', 'none')
+  .style('font-size', '12px')
+  .style('font-weight', 'bold')
+  .text(function(d) {
+    // For "Son of" relationships, highlight them with a special format
+    if (d.label && (d.label.includes("Son of") || d.label.includes("Child of") || 
+                    d.label.includes("Parent of") || d.label.includes("Father of") || 
+                    d.label.includes("Mother of"))) {
+      return d.label;
+    }
+    return d.label || '';
+  });
 </script>
 </body>
 </html>

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741036375">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741036375">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741038837">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741038837">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -780,6 +780,17 @@ $(document).ready(function() {
     justify-content: center; /* Center horizontally */
     align-items: center;     /* Center vertically */
   }
+  #loading {
+    position: absolute;
+    inset: 0;
+    background-color: white;
+    z-index: 30;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 1;
+    transition: opacity 0.3s ease-out;
+  }
   #legend {
     display: flex;
     align-items: flex-start;
@@ -989,12 +1000,22 @@ It shows the generated graph and a legend, plus a button to go back to the searc
     <defs>
       <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
         markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-        <path d="M 0 0 L 10 5 L 0 10 z" fill="#94A3B8" />
+        <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-path"></path>
       </marker>
       <!-- Category-specific markers will be added dynamically by D3 -->
     </defs>
     <g id="graph-content"></g>
   </svg>
+  <!-- Add loading overlay with the same styling as in expose/index.html -->
+  <div id="loading" class="absolute inset-0 flex flex-col items-center justify-center pt-5 bg-white z-30">
+    <div class="text-center">
+      <svg class="animate-spin h-8 w-8 text-navy mx-auto mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+      </svg>
+      <div id="loading-text" class="text-lg font-semibold text-navy mb-4">Loading graph...</div>
+    </div>
+  </div>
   <div id="loading-indicator" class="absolute">
     <img src="../assets/images/loading.svg" class="loading-spinner" style="width:32px;height:32px" alt="Loading...">
   </div>
@@ -1902,6 +1923,11 @@ function renderD3Graph(rootSubject, nodes, edges) {
   
   // Hide loading indicator when rendering starts
   $('#loading-indicator').hide();
+  // Note: We keep the main 'loading' overlay visible until the graph is fully centered
+  // That will be hidden in the centerGraph function when "Graph centered based on actual bounds" is logged
+  
+  // Update loading text to show that the graph is being processed
+  $('#loading-text').text('Rendering graph visualization...');
   
   // Initialize container dimensions
   const container = document.getElementById('graph-container');
@@ -2336,6 +2362,16 @@ function centerGraph() {
       graphCenter: { x: graphCenterX, y: graphCenterY },
       translation: { x: translateX, y: translateY }
     });
+    
+    // Hide the loading overlay when the graph is fully loaded and centered
+    const loadingEl = document.getElementById('loading');
+    if (loadingEl) {
+      loadingEl.style.opacity = '0';
+      loadingEl.style.transition = 'opacity 0.3s ease-out';
+      setTimeout(() => {
+        loadingEl.style.display = 'none';
+      }, 300);
+    }
   } catch (error) {
     console.error('Error centering graph:', error);
   }
@@ -3036,6 +3072,29 @@ function zoomToFitAll() {
     zoom.transform,
     d3.zoomIdentity.translate(translateX, translateY).scale(scale)
   );
+}
+
+function buildGraph(subject, filterKeywords = []) {
+  // Update page title with subject name
+  try {
+    const subjectName = nameFromEntityId(subject);
+    document.title = `${subjectName} - People Relations`;
+    $('#graphTitle').text(`${subjectName} - Relationship Graph`);
+  } catch (e) {
+    document.title = "People Relations";
+    $('#graphTitle').text("Relationship Graph");
+  }
+  
+  // Update loading overlay text
+  $('#loading-text').text('Preparing graph data...');
+  $('#loading').show(); // Ensure loading overlay is visible
+  
+  // Show loading indicator
+  $('#loading-indicator').show();
+  
+  // Start fetch process
+  const relationsZip = `../data/${subject}.zip`;
+  // ... existing code ...
 }
 </script>
 </body>

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741043449">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741043449">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741044464">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741044464">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -1007,13 +1007,16 @@ It shows the generated graph and a legend, plus a button to go back to the searc
     <g id="graph-content"></g>
   </svg>
   <!-- Add loading overlay with the same styling as in expose/index.html -->
-  <div id="loading" class="absolute inset-0 flex flex-col items-center justify-center pt-5 bg-white z-30">
+  <div id="loading" class="absolute inset-0 flex flex-col items-center justify-start pt-16 bg-white z-30">
     <div class="text-center">
       <svg class="animate-spin h-8 w-8 text-navy mx-auto mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
         <path fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
       </svg>
       <div id="loading-text" class="text-lg font-semibold text-navy mb-4">Loading graph...</div>
+      <div id="loading-nodes" class="text-gray-600 max-w-md mx-auto text-center max-h-[50vh] overflow-y-auto px-4">
+        <!-- Node names will be added here -->
+      </div>
     </div>
   </div>
   <div id="loading-indicator" class="absolute">
@@ -1930,14 +1933,8 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Update loading text to show that the graph is being processed
   $('#loading-text').text('Rendering graph visualization...');
   
-  // Add a timeout to ensure loading overlay is hidden even if other mechanisms fail
-  setTimeout(() => {
-    console.log("Timeout check - ensuring loading overlay is hidden");
-    if (document.getElementById('loading')) {
-      document.getElementById('loading').style.display = 'none';
-    }
-    $('#loading-indicator').hide();
-  }, 10000); // 10 seconds should be plenty for the graph to render
+  // Remove the premature timeout - we'll let the centerGraph function handle hiding the overlay
+  // instead of this fixed 10-second timer
   
   // Initialize container dimensions
   const container = document.getElementById('graph-container');
@@ -2037,7 +2034,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
   console.log(`Filtered to ${validEdges.length} valid edges`);
   
   // Identify first-level nodes (directly connected to root)
-  const firstLevelNodeIds = new Set();
+  window.firstLevelNodeIds = new Set();
   validEdges.forEach(edge => {
     if (edge.from === rootSubject) {
       firstLevelNodeIds.add(edge.to);
@@ -2050,6 +2047,8 @@ function renderD3Graph(rootSubject, nodes, edges) {
   
   console.log(`Identified ${firstLevelNodeIds.size} first-level nodes`);
   console.log('First-level nodes:', Array.from(firstLevelNodeIds));
+  
+  // We'll call displayNodesProgressively() after nodeElements is defined
   
   // Add arrow markers for links
   const defs = g.append('defs');
@@ -2128,6 +2127,9 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .on('end', dragEnded)
     );
    
+  // Start displaying first-level nodes progressively now that nodeElements is defined
+  displayNodesProgressively();
+  
   // Add rectangles to nodes
   nodeElements.append('rect')
     .attr('rx', 4)
@@ -2560,12 +2562,83 @@ function renderD3Graph(rootSubject, nodes, edges) {
       // When the simulation ends, center the graph based on actual content bounds
       centerGraph();
       
-      // Failsafe: directly hide loading elements in case centerGraph didn't do it
-      console.log("Simulation ended - ensuring loading overlay is hidden");
-      document.getElementById('loading').style.display = 'none';
-      $('#loading-indicator').hide();
-      $('#loading-overlay').hide();
+      // We'll move the progressive display and failsafe to after centerGraph completes
+      // by letting centerGraph call displayNodesProgressively
     });
+}
+
+// Function to display nodes progressively after data is fully loaded
+function displayNodesProgressively() {
+  try {
+    const loadingNodesDiv = document.getElementById('loading-nodes');
+    if (!loadingNodesDiv) {
+      console.warn("Loading nodes div not found");
+      return;
+    }
+    
+    loadingNodesDiv.innerHTML = ''; // Clear any existing content
+    
+    // Check if nodeElements exists - if not, we can't display nodes yet
+    if (!nodeElements) {
+      console.warn("Node elements not available yet, cannot display nodes progressively");
+      return;
+    }
+    
+    // Get root node
+    const rootNode = nodeElements.filter(d => d.id === rootSubject).data()[0];
+    
+    // Find first-level nodes (directly connected to root)
+    // Use window.firstLevelNodeIds to ensure we access the global variable
+    const firstLevelNodes = nodeElements.filter(d => window.firstLevelNodeIds.has(d.id)).data();
+    
+    console.log(`Displaying ${firstLevelNodes.length} first-level nodes progressively`);
+    
+    // Add root node first
+    if (rootNode) {
+      const rootDiv = document.createElement('div');
+      rootDiv.className = 'font-bold opacity-0 transition-opacity duration-300 py-1';
+      rootDiv.textContent = rootNode.id;
+      loadingNodesDiv.appendChild(rootDiv);
+      
+      // Trigger fade in for root node
+      setTimeout(() => {
+        rootDiv.style.opacity = '1';
+      }, 100);
+    }
+    
+    // Add first-level nodes progressively
+    let nodeIndex = 0;
+    function addNextNode() {
+      if (nodeIndex < firstLevelNodes.length) {
+        const node = firstLevelNodes[nodeIndex];
+        
+        // Create element for this node
+        const div = document.createElement('div');
+        div.className = 'opacity-0 transition-opacity duration-300 py-1';
+        div.textContent = node.id;
+        
+        // Add to container
+        loadingNodesDiv.appendChild(div);
+        
+        // Trigger fade in and scroll to bottom
+        setTimeout(() => {
+          div.style.opacity = '1';
+          loadingNodesDiv.scrollTop = loadingNodesDiv.scrollHeight;
+        }, 50);
+        
+        // Move to next node
+        nodeIndex++;
+        
+        // Schedule next node with 1 second delay
+        setTimeout(addNextNode, 1000);
+      }
+    }
+    
+    // Start adding nodes with a short delay
+    setTimeout(addNextNode, 500);
+  } catch (error) {
+    console.error("Error displaying nodes progressively:", error);
+  }
 }
 
 // Function to center the graph based on its actual rendered bounds
@@ -2609,14 +2682,21 @@ function centerGraph() {
         .scale(initialScale)
     );
     
+    console.log("Graph centered based on actual bounds");
+    
+    // Now the nodes are already being displayed progressively before centering
+    // so we don't need to call displayNodesProgressively here
+    
     // Hide loading overlay and indicators
     document.getElementById('loading').style.display = 'none';
     $('#loading-indicator').hide();
     $('#loading-overlay').fadeOut();
-    
-    console.log("Loading overlay hidden");
   } catch (error) {
     console.error("Error centering graph:", error);
+    
+    // Failsafe: Ensure loading overlay is hidden even if there's an error
+    document.getElementById('loading').style.display = 'none';
+    $('#loading-indicator').hide();
   }
 }
 

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741028865">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741028865">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741029015">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741029015">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -2677,9 +2677,12 @@ function getNodeWidth(node) {
     const bullet1 = bulletInfo.bullet_point1 || '';
     const bullet2 = bulletInfo.bullet_point2 || '';
     
+    // Use consistent padding for all nodes
+    const padding = 12;
+    
     // If there are no bullet points, use a smaller width
     if (bullet1.length === 0 && bullet2.length === 0) {
-      node._width = Math.max(textLength * 8 + 40, 120);
+      node._width = Math.max(textLength * 8 + padding * 2, 120);
       return node._width;
     }
     
@@ -2695,8 +2698,8 @@ function getNodeWidth(node) {
     // This ensures text fills the box better
     const targetCharsPerLine = 45;
     const contentBasedWidth = Math.min(
-      Math.max(longestBullet.length, textLength * 1.5) * charWidth + 40,
-      targetCharsPerLine * charWidth + 40
+      Math.max(longestBullet.length, textLength * 1.5) * charWidth + padding * 2,
+      targetCharsPerLine * charWidth + padding * 2
     );
     
     node._width = Math.max(contentBasedWidth, 220);

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741045012">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741045012">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741045261">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741045261">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -1003,7 +1003,7 @@ It shows the generated graph and a legend, plus a button to go back to the searc
         <path fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
       </svg>
       <div id="loading-text" class="text-lg font-semibold text-navy mb-4">Loading graph...</div>
-      <div id="loading-nodes" class="text-gray-600 max-w-md mx-auto text-center max-h-[50vh] overflow-y-auto px-4">
+      <div id="loading-nodes" class="text-gray-600 max-w-md mx-auto text-center px-4 max-h-[80vh] overflow-y-auto">
         <!-- Node names will be added here -->
       </div>
     </div>
@@ -2596,7 +2596,6 @@ function displayNodesProgressively() {
       // Add text indicating this is the root node
       const relationSpan = document.createElement('div');
       relationSpan.className = 'text-sm opacity-80 ml-2';
-      relationSpan.textContent = '(root node)';
       rootDiv.appendChild(relationSpan);
       
       loadingNodesDiv.appendChild(rootDiv);
@@ -2604,7 +2603,7 @@ function displayNodesProgressively() {
       // Trigger fade in for root node
       setTimeout(() => {
         rootDiv.style.opacity = '1';
-      }, 100);
+      }, 150);
     }
     
     // Function to find relationship labels between root and a node

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741029015">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741029015">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741029178">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741029178">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -1039,14 +1039,14 @@ let globalActiveCategories = new Set(); // which categories are currently on dis
 
 // Force simulation parameters
 const forceParams = {
-  linkDistance: 400,
-  charge: -3000,
-  collisionRadius: 200,
+  linkDistance: 600,     // Increased from 400
+  charge: -5000,         // Increased from -3000
+  collisionRadius: 300,  // Increased from 200
   bounds: {
-    left: 100,
-    right: 100,
-    top: 100,
-    bottom: 100
+    left: 150,
+    right: 150,
+    top: 150,
+    bottom: 150
   }
 };
 
@@ -1822,7 +1822,7 @@ function initializeD3Graph() {
     .call(zoom)
     .on('dblclick.zoom', null); // Disable double-click zoom
     
-  // Reset zoom and pan
+  // Reset zoom and pan with initial scale of 0.7 to show more of the graph
   resetZoom();
   
   // Show loading indicator
@@ -1830,9 +1830,10 @@ function initializeD3Graph() {
 }
 
 function resetZoom() {
+  // Start with a zoomed-out view (scale 0.7) to show more of the graph
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(width/2, height/2)
+    d3.zoomIdentity.translate(width/2, height/2).scale(0.7)
   );
 }
 
@@ -2436,135 +2437,143 @@ function ticked() {
   }
 }
 
-// Function to prevent label overlaps with nodes
+// Function to prevent label overlaps with nodes and other labels
 function preventLabelOverlaps() {
   try {
-    // For each label, check if it overlaps with any node
+    // First collect all node rectangles for overlap checking
+    const nodeRects = [];
+    nodeElements.each(function(d) {
+      nodeRects.push({
+        x: d.x - getNodeWidth(d) / 2,
+        y: d.y - getNodeHeight(d) / 2,
+        width: getNodeWidth(d),
+        height: getNodeHeight(d),
+        id: d.id
+      });
+    });
+    
+    // Collect all label rectangles
+    const labelRects = [];
     labelElements.each(function(d) {
-      try {
-        const labelGroup = d3.select(this);
-        const labelBg = labelGroup.select('.label-bg');
-        
-        // Skip if no background element
-        if (labelBg.empty()) return;
-        
-        // Get the label's bounding box
-        const labelBBox = labelBg.node().getBBox();
-        if (!labelBBox) return;
-        
-        // Current label position
-        const labelX = d.labelX || 0;
-        const labelY = d.labelY || 0;
-        
-        // Create a rectangle representing the label's current position
-        const labelRect = {
-          x: labelX - labelBBox.width / 2,
-          y: labelY - labelBBox.height / 2,
-          width: labelBBox.width,
-          height: labelBBox.height
-        };
+      const labelGroup = d3.select(this);
+      const labelBg = labelGroup.select('.label-bg');
+      
+      // Skip if no background element
+      if (labelBg.empty()) return;
+      
+      // Get the label's bounding box
+      const labelBBox = labelBg.node().getBBox();
+      if (!labelBBox) return;
+      
+      // Current label position
+      const labelX = d.labelX || 0;
+      const labelY = d.labelY || 0;
+      
+      labelRects.push({
+        x: labelX - labelBBox.width / 2,
+        y: labelY - labelBBox.height / 2,
+        width: labelBBox.width,
+        height: labelBBox.height,
+        edge: d,
+        group: labelGroup,
+        originalX: labelX,
+        originalY: labelY
+      });
+    });
+    
+    // Process each label to avoid overlaps
+    for (let i = 0; i < labelRects.length; i++) {
+      const labelRect = labelRects[i];
+      let hasOverlap = true;
+      let attempts = 0;
+      const maxAttempts = 10;
+      
+      // Try to find a position without overlaps
+      while (hasOverlap && attempts < maxAttempts) {
+        hasOverlap = false;
+        attempts++;
         
         // Check for overlaps with nodes
-        let maxOverlap = 0;
-        nodeElements.each(function(nodeData) {
-          const nodeRect = {
-            x: nodeData.x - getNodeWidth(nodeData) / 2,
-            y: nodeData.y - getNodeHeight(nodeData) / 2,
-            width: getNodeWidth(nodeData),
-            height: getNodeHeight(nodeData)
-          };
-          
-          // Calculate overlap area
-          const overlapArea = calculateOverlapArea(labelRect, nodeRect);
-          maxOverlap = Math.max(maxOverlap, overlapArea);
-        });
-        
-        // If there's significant overlap, try to reposition the label
-        if (maxOverlap > 0) {
-          // Get source and target IDs
-          const sourceId = d.from;
-          const targetId = d.to;
-          
-          if (!sourceId || !targetId) return;
-          
-          // Find the path for this label
-          let path = d.path;
-          
-          // If path is not stored, try to find it
-          if (!path) {
-            path = d3.select(`path[data-source="${sourceId}"][data-target="${targetId}"]`).node();
-            if (!path) {
-              console.log('No path found for label:', sourceId, targetId);
-              return;
-            }
-            d.path = path;
-          }
-          
-          const pathLength = path.getTotalLength();
-          if (!pathLength || pathLength <= 0) {
-            console.log('Invalid path length:', pathLength);
-            return;
-          }
-          
-          // Try different positions along the path
-          let bestPosition = 0.5; // Default to midpoint
-          let minOverlap = maxOverlap;
-          
-          // Test positions at 5% increments
-          for (let pos = 0.05; pos <= 0.95; pos += 0.05) {
-            if (pos === 0.5) continue; // Skip the current position
+        for (const nodeRect of nodeRects) {
+          if (rectsOverlap(labelRect, nodeRect)) {
+            hasOverlap = true;
             
-            const testPoint = path.getPointAtLength(pathLength * pos);
-            
-            // Create a rectangle for this test position
-            const testRect = {
-              x: testPoint.x - labelBBox.width / 2,
-              y: testPoint.y - labelBBox.height / 2,
-              width: labelBBox.width,
-              height: labelBBox.height
-            };
-            
-            // Check overlap with all nodes
-            let testMaxOverlap = 0;
-            nodeElements.each(function(nodeData) {
-              const nodeRect = {
-                x: nodeData.x - getNodeWidth(nodeData) / 2,
-                y: nodeData.y - getNodeHeight(nodeData) / 2,
-                width: getNodeWidth(nodeData),
-                height: getNodeHeight(nodeData)
-              };
-              
-              const overlapArea = calculateOverlapArea(testRect, nodeRect);
-              testMaxOverlap = Math.max(testMaxOverlap, overlapArea);
-            });
-            
-            // If this position has less overlap, use it
-            if (testMaxOverlap < minOverlap) {
-              minOverlap = testMaxOverlap;
-              bestPosition = pos;
-            }
-          }
-          
-          // If we found a better position, update the label
-          if (bestPosition !== 0.5) {
-            const newPoint = path.getPointAtLength(pathLength * bestPosition);
-            
-            // Update stored position
-            d.labelX = newPoint.x;
-            d.labelY = newPoint.y;
-            
-            // Update transform
-            labelGroup.attr('transform', `translate(${newPoint.x}, ${newPoint.y})`);
-            
-            console.log('Repositioned label to reduce overlap:', sourceId, targetId, bestPosition);
+            // Try to move the label away from the node
+            repositionLabelAwayFromRect(labelRect, nodeRect);
+            break;
           }
         }
-      } catch (error) {
-        console.error("Error in label overlap prevention for label:", error, d);
+        
+        // If no node overlaps, check for overlaps with other labels
+        if (!hasOverlap) {
+          for (let j = 0; j < i; j++) {
+            if (rectsOverlap(labelRect, labelRects[j])) {
+              hasOverlap = true;
+              
+              // Try to move the label away from the other label
+              repositionLabelAwayFromRect(labelRect, labelRects[j]);
+              break;
+            }
+          }
+        }
       }
-    });
+      
+      // Update the label position
+      labelRect.group.attr('transform', `translate(${labelRect.x + labelRect.width/2}, ${labelRect.y + labelRect.height/2})`);
+      
+      // Update stored position for future reference
+      labelRect.edge.labelX = labelRect.x + labelRect.width/2;
+      labelRect.edge.labelY = labelRect.y + labelRect.height/2;
+    }
   } catch (error) {
     console.error("Error in preventLabelOverlaps:", error);
+  }
+}
+
+// Helper function to check if two rectangles overlap
+function rectsOverlap(rect1, rect2) {
+  return !(
+    rect1.x + rect1.width < rect2.x ||
+    rect2.x + rect2.width < rect1.x ||
+    rect1.y + rect1.height < rect2.y ||
+    rect2.y + rect2.height < rect1.y
+  );
+}
+
+// Helper function to reposition a label away from an overlapping rectangle
+function repositionLabelAwayFromRect(labelRect, overlapRect) {
+  // Calculate centers
+  const labelCenterX = labelRect.x + labelRect.width / 2;
+  const labelCenterY = labelRect.y + labelRect.height / 2;
+  const rectCenterX = overlapRect.x + overlapRect.width / 2;
+  const rectCenterY = overlapRect.y + overlapRect.height / 2;
+  
+  // Calculate direction vector from overlapping rect to label
+  const dirX = labelCenterX - rectCenterX;
+  const dirY = labelCenterY - rectCenterY;
+  
+  // Normalize direction vector
+  const length = Math.sqrt(dirX * dirX + dirY * dirY);
+  const normDirX = length > 0 ? dirX / length : 0;
+  const normDirY = length > 0 ? dirY / length : 1; // Default to moving down if centers are the same
+  
+  // Calculate minimum distance needed to avoid overlap
+  const minDistX = (labelRect.width + overlapRect.width) / 2;
+  const minDistY = (labelRect.height + overlapRect.height) / 2;
+  
+  // Move primarily in the direction with the least overlap
+  const overlapX = minDistX - Math.abs(labelCenterX - rectCenterX);
+  const overlapY = minDistY - Math.abs(labelCenterY - rectCenterY);
+  
+  // Add a small buffer to ensure no overlap
+  const buffer = 10;
+  
+  if (overlapX < overlapY) {
+    // Move horizontally
+    labelRect.x += (overlapX + buffer) * Math.sign(normDirX);
+  } else {
+    // Move vertically
+    labelRect.y += (overlapY + buffer) * Math.sign(normDirY);
   }
 }
 

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741046045">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741046045">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741046595">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741046595">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -778,7 +778,8 @@ $(document).ready(function() {
     overflow: hidden;  /* if you like; up to you */
     display: flex;     /* Add flexbox to center content */
     justify-content: center; /* Center horizontally */
-    align-items: center;     /* Center vertically */
+    align-items: flex-start; /* Align to the top instead of center */
+    padding-top: 20px; /* Add some padding at the top */
   }
   #legend {
     display: flex;
@@ -1906,7 +1907,7 @@ function resetZoom() {
   // In hierarchical layout, we want to center more towards the top where the root node is
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(0, height * 0.2).scale(0.5) // Shift up slightly to focus on root
+    d3.zoomIdentity.translate(0, height * -0.1).scale(0.5) // Move even higher by using negative value
   );
 }
 
@@ -1950,14 +1951,14 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Reset zoom and pan with centered graph
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(0, 0).scale(0.5) // More zoomed out to see the entire graph
+    d3.zoomIdentity.translate(0, -height * 0.25).scale(0.5) // Increase negative offset to move higher
   );
   
   // Create the graph content group with initial transform
   const g = d3.select('#graph-content');
   
   // Explicitly set an initial transform on the graph content to center it
-  g.attr('transform', `translate(${width/2}, ${height/2})`);
+  g.attr('transform', `translate(${width/2}, ${height/4})`); // Position at 1/4 height instead of 1/3
   
   // Store the root subject for reference in other functions
   window.rootSubject = rootSubject;
@@ -1972,13 +1973,12 @@ function renderD3Graph(rootSubject, nodes, edges) {
     nodeMap.set(node.id, node);
   });
   
-  // Pre-position nodes in a structured layout - critical for avoiding initial overlaps
   // Position root node at the top center
   if (rootNode) {
     rootNode.x = 0; // Center horizontally
-    rootNode.y = -height * 0.35; // Position at top
+    rootNode.y = -height * 0.7; // Increased negative value to position even higher
     rootNode.fx = 0; // Fix position horizontally
-    rootNode.fy = -height * 0.35; // Fix position vertically
+    rootNode.fy = -height * 0.7; // Increased negative value to position even higher
   }
   
   // Arrange non-root nodes in a semi-circle below the root node
@@ -1987,7 +1987,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     // Use a semi-circle (180 degrees) below the root
     const angle = (Math.PI * i) / (nonRootNodes.length - 1);
     node.x = radius * Math.cos(angle); // Position in semi-circle
-    node.y = -height * 0.35 + radius * Math.sin(angle) + radius; // Position below root node
+    node.y = -height * 0.7 + radius * Math.sin(angle) + radius; // Position below root node
   });
   
   // Preprocess edges to ensure all source and target nodes exist
@@ -2485,7 +2485,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
       return d.x;
     }).strength(0.25))
     .force('y', d3.forceY(d => {
-      if (d.id === rootSubject) return -height * 0.4;
+      if (d.id === rootSubject) return -height * 0.7; // Increased negative value for higher positioning
       if (firstLevelNodeIds.has(d.id)) {
         return d.y; // Keep first level at their y positions
       }
@@ -2548,7 +2548,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     }).strength(d => d.id === rootSubject ? 1 : 0.3)) // Increased from 0.2 for faster positioning
     .force('y', d3.forceY(d => {
       // Keep root at top
-      if (d.id === rootSubject) return -height * 0.3; // Reduced from 0.4
+      if (d.id === rootSubject) return -height * 0.7; // Increased negative value for higher positioning
       
       // First level nodes position
       if (firstLevelNodeIds.has(d.id)) {
@@ -2712,11 +2712,11 @@ function centerGraph() {
     // Calculate the center of the graph content with emphasis on the root node
     // For knowledge graphs, we want the root higher in the viewport
     const graphCenterX = bbox.x + bbox.width / 2;
-    const graphCenterY = bbox.y + bbox.height * 0.35; // 35% point to shift focus upward
+    const graphCenterY = bbox.y + bbox.height * 0.15; // 15% point to shift focus even further upward
     
     // Calculate the translation needed to center the graph
     const translateX = viewportWidth / 2 - graphCenterX;
-    const translateY = viewportHeight / 2 - graphCenterY;
+    const translateY = viewportHeight / 5 - graphCenterY; // Position at 1/5 of the height instead of 1/3
     console.log("Translation:", translateX, translateY);
     
     // Determine appropriate initial scale based on the graph size
@@ -2763,9 +2763,9 @@ function ticked() {
     simulation.nodes().forEach(d => {
       if (d.id === rootSubject) {
         d.x = 0;
-        d.y = -height * 0.4;
+        d.y = -height * 0.5; // Increased to position higher (was 0.4)
         d.fx = 0;
-        d.fy = -height * 0.4;
+        d.fy = -height * 0.5; // Increased to position higher (was 0.4)
       }
     });
     

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741044464">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741044464">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741045012">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741045012">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -780,17 +780,6 @@ $(document).ready(function() {
     justify-content: center; /* Center horizontally */
     align-items: center;     /* Center vertically */
   }
-  #loading {
-    position: absolute;
-    inset: 0;
-    background-color: white;
-    z-index: 30;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    opacity: 1;
-    transition: opacity 0.3s ease-out;
-  }
   #legend {
     display: flex;
     align-items: flex-start;
@@ -1007,7 +996,7 @@ It shows the generated graph and a legend, plus a button to go back to the searc
     <g id="graph-content"></g>
   </svg>
   <!-- Add loading overlay with the same styling as in expose/index.html -->
-  <div id="loading" class="absolute inset-0 flex flex-col items-center justify-start pt-16 bg-white z-30">
+  <div id="loading" class="absolute inset-0 flex flex-col items-center justify-start bg-white pt-4 h-full z-30">
     <div class="text-center">
       <svg class="animate-spin h-8 w-8 text-navy mx-auto mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -1931,7 +1920,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // That will be hidden in the centerGraph function when "Graph centered based on actual bounds" is logged
   
   // Update loading text to show that the graph is being processed
-  $('#loading-text').text('Rendering graph visualization...');
+  $('#loading-text').text('Analyzing connections...');
   
   // Remove the premature timeout - we'll let the centerGraph function handle hiding the overlay
   // instead of this fixed 10-second timer
@@ -2596,14 +2585,42 @@ function displayNodesProgressively() {
     // Add root node first
     if (rootNode) {
       const rootDiv = document.createElement('div');
-      rootDiv.className = 'font-bold opacity-0 transition-opacity duration-300 py-1';
-      rootDiv.textContent = rootNode.id;
+      rootDiv.className = 'opacity-0 transition-opacity duration-300 py-1';
+      
+      // Add the root node ID as the main text
+      const nodeIdSpan = document.createElement('div');
+      nodeIdSpan.className = 'font-bold';
+      nodeIdSpan.textContent = rootNode.id;
+      rootDiv.appendChild(nodeIdSpan);
+      
+      // Add text indicating this is the root node
+      const relationSpan = document.createElement('div');
+      relationSpan.className = 'text-sm opacity-80 ml-2';
+      relationSpan.textContent = '(root node)';
+      rootDiv.appendChild(relationSpan);
+      
       loadingNodesDiv.appendChild(rootDiv);
       
       // Trigger fade in for root node
       setTimeout(() => {
         rootDiv.style.opacity = '1';
       }, 100);
+    }
+    
+    // Function to find relationship labels between root and a node
+    function getRelationshipLabels(nodeId) {
+      const relationships = [];
+      
+      // Check for edges from root to this node
+      window.edges.forEach(edge => {
+        if (edge.from === rootSubject && edge.to === nodeId) {
+          relationships.push(edge.label || "unlabeled relation");
+        } else if (edge.to === rootSubject && edge.from === nodeId) {
+          relationships.push(edge.label || "unlabeled relation");
+        }
+      });
+      
+      return relationships;
     }
     
     // Add first-level nodes progressively
@@ -2614,8 +2631,23 @@ function displayNodesProgressively() {
         
         // Create element for this node
         const div = document.createElement('div');
-        div.className = 'opacity-0 transition-opacity duration-300 py-1';
-        div.textContent = node.id;
+        div.className = 'opacity-0 transition-opacity duration-300 py-2';
+        
+        // Add the node ID as the main text
+        const nodeIdSpan = document.createElement('div');
+        nodeIdSpan.textContent = node.id;
+        div.appendChild(nodeIdSpan);
+        
+        // Add relationship labels
+        const relationships = getRelationshipLabels(node.id);
+        if (relationships.length > 0) {
+          relationships.forEach(label => {
+            const relationSpan = document.createElement('div');
+            relationSpan.className = 'text-sm opacity-80 ml-2';
+            relationSpan.textContent = label;
+            div.appendChild(relationSpan);
+          });
+        }
         
         // Add to container
         loadingNodesDiv.appendChild(div);

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741050051">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741050051">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741050220">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741050220">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -3212,11 +3212,13 @@ function preventLabelOverlaps() {
     // First collect all node rectangles for overlap checking
     const nodeRects = [];
     nodeElements.each(function(d) {
+      // Add extra padding around nodes
+      const extraPadding = 40;
       nodeRects.push({
-        x: d.x - getNodeWidth(d) / 2,
-        y: d.y - getNodeHeight(d) / 2,
-        width: getNodeWidth(d),
-        height: getNodeHeight(d),
+        x: d.x - getNodeWidth(d) / 2 - extraPadding,
+        y: d.y - getNodeHeight(d) / 2 - extraPadding,
+        width: getNodeWidth(d) + extraPadding * 2,
+        height: getNodeHeight(d) + extraPadding * 2,
         id: d.id,
         type: 'node',
         center: { x: d.x, y: d.y }
@@ -3263,16 +3265,15 @@ function preventLabelOverlaps() {
     });
     
     // Process each label to avoid overlaps
-    for (let i = 0; i < labelRects.length; i++) {
-      const labelRect = labelRects[i];
+    for (const labelRect of labelRects) {
       let hasOverlap = true;
       let attempts = 0;
-      const maxAttempts = 10; // Limit repositioning attempts
+      const maxAttempts = 12; // Increased from default
       
-      // Try to find a position without overlaps
       while (hasOverlap && attempts < maxAttempts) {
         hasOverlap = false;
         attempts++;
+        
         
         // Check for overlaps with nodes
         for (const nodeRect of nodeRects) {
@@ -3308,11 +3309,14 @@ function preventLabelOverlaps() {
             const midX = (sourceCenter.x + targetCenter.x) / 2;
             const midY = (sourceCenter.y + targetCenter.y) / 2;
             
-            // Calculate distance to place label
-            const distance = Math.max(labelRect.width, labelRect.height) * 1.5;
+            // Calculate distance to place label - increased for more spacing
+            const baseDistance = Math.max(labelRect.width, labelRect.height) * 2;
+            const distance = baseDistance + (attempts * 20); // Gradually increase distance with each attempt
             
-            // Try different angles
-            const angle = (Math.PI * 2 * attempts) / maxAttempts;
+            // Try different angles with slight randomization
+            const angleStep = (Math.PI * 2) / maxAttempts;
+            const angle = angleStep * attempts + (Math.random() * 0.2 - 0.1);
+            
             labelRect.x = midX + Math.cos(angle) * distance - labelRect.width / 2;
             labelRect.y = midY + Math.sin(angle) * distance - labelRect.height / 2;
           }
@@ -3336,8 +3340,8 @@ function preventLabelOverlaps() {
 
 // Helper function to check if two rectangles overlap
 function rectsOverlap(rect1, rect2) {
-  // Add a buffer zone to ensure labels don't touch
-  const buffer = 25; // Increased buffer
+  // Add a larger buffer zone to ensure labels don't touch
+  const buffer = 35; // Increased from 25
   
   return !(
     rect1.x + rect1.width + buffer < rect2.x ||

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741031089">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741031089">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741031522">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741031522">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -1866,7 +1866,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Reset zoom and pan
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(width/2, height/2).scale(0.7) // Start with a zoomed-out view
+    d3.zoomIdentity.translate(width/2, height/2).scale(0.6) // Start with a more zoomed-out view
   );
   
   // Create the graph content group
@@ -2212,17 +2212,17 @@ function renderD3Graph(rootSubject, nodes, edges) {
           
           if (!sourceNode || !targetNode) {
             console.warn("Missing node in link distance calculation");
-            return forceParams.linkDistance;
+            return forceParams.linkDistance * 2.0; // Further increased distance
           }
           
           const sourceSize = Math.sqrt(getNodeWidth(sourceNode) * getNodeHeight(sourceNode));
           const targetSize = Math.sqrt(getNodeWidth(targetNode) * getNodeHeight(targetNode));
           
           // Base distance on node sizes plus padding - increased for better spacing
-          return (sourceSize + targetSize) / 2 + forceParams.linkDistance * 1.5; // Increased distance multiplier
+          return (sourceSize + targetSize) / 2 + forceParams.linkDistance * 2.0; // Further increased distance multiplier
         } catch (error) {
           console.error("Error in link distance calculation:", error, d);
-          return forceParams.linkDistance * 1.5; // Increased default distance
+          return forceParams.linkDistance * 2.0; // Further increased default distance
         }
       })
     )
@@ -2230,28 +2230,28 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .strength(d => {
         // Stronger repulsion for structured layout
         const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
-        return forceParams.charge * (nodeSize / 200) * 2.0; // Increased repulsion
+        return forceParams.charge * (nodeSize / 200) * 2.5; // Further increased repulsion
       })
-      .distanceMin(250) // Increased minimum distance
-      .distanceMax(2500)) // Increased maximum distance
+      .distanceMin(300) // Further increased minimum distance
+      .distanceMax(3000)) // Further increased maximum distance
     .force('x', d3.forceX(d => {
       // Keep root node centered, let others spread horizontally
       if (d.id === rootSubject) return width / 2;
       return d.x; // Use pre-positioned x value
-    }).strength(d => d.id === rootSubject ? 1 : 0.15)) // Reduced strength to allow more movement
+    }).strength(d => d.id === rootSubject ? 1 : 0.1)) // Further reduced strength to allow more movement
     .force('y', d3.forceY(d => {
       // Keep root node at top, others in row below
       if (d.id === rootSubject) return height * 0.2;
       return height * 0.7;
-    }).strength(0.2)) // Reduced strength to allow more movement
+    }).strength(0.15)) // Further reduced strength to allow more movement
     .force('collision', d3.forceCollide().radius(d => {
       // Make collision radius based on node size plus padding
       const nodeWidth = getNodeWidth(d);
       const nodeHeight = getNodeHeight(d);
-      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 100; // Increased padding significantly
+      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 120; // Further increased padding significantly
     }).strength(1))
-    .alpha(0.8) // Higher alpha for more movement
-    .alphaDecay(0.006) // Slower decay for more time to find optimal positions
+    .alpha(0.9) // Higher alpha for more movement
+    .alphaDecay(0.005) // Slower decay for more time to find optimal positions
     .velocityDecay(0.4)
     .on('tick', ticked);
 }
@@ -2497,7 +2497,8 @@ function preventLabelOverlaps() {
         width: getNodeWidth(d),
         height: getNodeHeight(d),
         id: d.id,
-        type: 'node'
+        type: 'node',
+        center: { x: d.x, y: d.y }
       });
     });
     
@@ -2518,6 +2519,12 @@ function preventLabelOverlaps() {
       const labelX = d.labelX || 0;
       const labelY = d.labelY || 0;
       
+      // Get source and target nodes for this edge
+      const sourceNode = nodeMap.get(d.from);
+      const targetNode = nodeMap.get(d.to);
+      
+      if (!sourceNode || !targetNode) return;
+      
       labelRects.push({
         x: labelX - labelBBox.width / 2,
         y: labelY - labelBBox.height / 2,
@@ -2527,7 +2534,10 @@ function preventLabelOverlaps() {
         group: labelGroup,
         originalX: labelX,
         originalY: labelY,
-        type: 'label'
+        type: 'label',
+        sourceNode: sourceNode,
+        targetNode: targetNode,
+        center: { x: labelX, y: labelY }
       });
     });
     
@@ -2566,6 +2576,26 @@ function preventLabelOverlaps() {
             }
           }
         }
+        
+        // If we still have overlaps after several attempts, try a more drastic approach
+        if (hasOverlap && attempts >= 5) {
+          // Try positioning at different angles around the midpoint between source and target
+          const sourceCenter = labelRect.sourceNode;
+          const targetCenter = labelRect.targetNode;
+          
+          if (sourceCenter && targetCenter) {
+            const midX = (sourceCenter.x + targetCenter.x) / 2;
+            const midY = (sourceCenter.y + targetCenter.y) / 2;
+            
+            // Calculate distance to place label
+            const distance = Math.max(labelRect.width, labelRect.height) * 1.5;
+            
+            // Try different angles
+            const angle = (Math.PI * 2 * attempts) / maxAttempts;
+            labelRect.x = midX + Math.cos(angle) * distance - labelRect.width / 2;
+            labelRect.y = midY + Math.sin(angle) * distance - labelRect.height / 2;
+          }
+        }
       }
       
       // Update the label position
@@ -2586,7 +2616,7 @@ function preventLabelOverlaps() {
 // Helper function to check if two rectangles overlap
 function rectsOverlap(rect1, rect2) {
   // Add a buffer zone to ensure labels don't touch
-  const buffer = 15;
+  const buffer = 25; // Increased buffer
   
   return !(
     rect1.x + rect1.width + buffer < rect2.x ||
@@ -2622,10 +2652,10 @@ function repositionLabelAwayFromRect(labelRect, overlapRect) {
   const overlapY = minDistY - Math.abs(labelCenterY - rectCenterY);
   
   // Add a larger buffer to ensure no overlap
-  const buffer = 20;
+  const buffer = 30; // Increased buffer
   
   // Move in the direction with the least overlap, but with a minimum movement
-  const moveDistance = Math.max(Math.min(overlapX, overlapY) + buffer, 30);
+  const moveDistance = Math.max(Math.min(overlapX, overlapY) + buffer, 40); // Increased minimum distance
   
   if (overlapX < overlapY) {
     // Move horizontally

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741031522">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741031522">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741033147">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741033147">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -1435,6 +1435,24 @@ async function renderGraphForSubject(subjectName) {
     if (!subject) {
       throw new Error(`Subject "${subjectName}" not found`);
     }
+    
+    // Populate the root summary div with bullet points
+    const rootSummaryHtml = [];
+    if (subject.bullet_point1) {
+      rootSummaryHtml.push(`<p class="mb-1">${escapeHtml(subject.bullet_point1)}</p>`);
+    }
+    if (subject.bullet_point2) {
+      rootSummaryHtml.push(`<p>${escapeHtml(subject.bullet_point2)}</p>`);
+    }
+    // If no bullet points, add a default message
+    if (rootSummaryHtml.length === 0) {
+      rootSummaryHtml.push(`<p class="text-gray-500 italic">No detailed information available for ${escapeHtml(subjectName)}.</p>`);
+    }
+    // Add a title for the summary
+    $('#rootSummary').html(`
+      <h3 class="font-bold mb-2 text-navy">${escapeHtml(subjectName)}</h3>
+      ${rootSummaryHtml.join('')}
+    `);
     
     // Load relations data for this subject
     await loadRelationsData(subjectName);

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741050220">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741050220">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741050497">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741050497">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -779,7 +779,6 @@ $(document).ready(function() {
     display: flex;     /* Add flexbox to center content */
     justify-content: center; /* Center horizontally */
     align-items: flex-start; /* Align to the top instead of center */
-    padding-top: 20px; /* Add some padding at the top */
   }
   #legend {
     display: flex;
@@ -808,12 +807,6 @@ $(document).ready(function() {
     fill: none;
     stroke-width: 2px;
     filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.05));
-  }
-  .label-bg {
-    fill: #F3F4F6;
-    stroke: white;
-    stroke-width: 2px;
-    filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.1));
   }
   .link-label {
     fill: #475569;
@@ -2216,6 +2209,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .attr('ry', 12)
     .attr('class', 'label-bg')
     .attr('fill', '#F3F4F6')
+    .attr('stroke', '#94A3B8')
     .attr('width', 10) // Initial size, will be updated in ticked
     .attr('height', 10)
     .attr('x', -5)

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741051087">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741051087">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741052050">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741052050">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -1442,7 +1442,13 @@ function renderSearchResult(subject, desc) {
   `);
 
   $div.css('cursor','pointer').on('click', function() {
-    window.location.href = '?subject=' + encodeURIComponent(subject);
+    // Get current search value
+    const searchValue = $('#searchBox').val().trim();
+    let url = '?subject=' + encodeURIComponent(subject);
+    if (searchValue) {
+      url += '&search=' + encodeURIComponent(searchValue);
+    }
+    window.location.href = url;
   });
 
   return $div;
@@ -1453,8 +1459,16 @@ function renderSearchResult(subject, desc) {
 * BACK TO SEARCH
 ***************************************/
 $('#backToSearch').on('click', function() {
+  const urlParams = new URLSearchParams(window.location.search);
+  const searchValue = urlParams.get('search');
+  
   const newUrl = new URL(window.location);
   newUrl.searchParams.delete('subject');
+  
+  if (searchValue) {
+    newUrl.searchParams.set('search', searchValue);
+  }
+  
   window.history.pushState({}, '', newUrl);
   window.location.reload();
 });

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741049765">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741049765">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741050051">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741050051">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -2127,12 +2127,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .data(nodes)
     .join('g')
     .attr('class', d => d.id === rootSubject ? 'node root' : 'node')
-    .attr('data-id', d => d.id)
-    .call(d3.drag()
-      .on('start', dragStarted)
-      .on('drag', dragged)
-      .on('end', dragEnded)
-    );
+    .attr('data-id', d => d.id);
    
   // Start displaying first-level nodes progressively now that nodeElements is defined
   displayNodesProgressively();
@@ -2146,7 +2141,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .attr('fill', 'white')
     .attr('stroke', d => d.id === rootSubject ? '#2563EB' : '#94A3B8')
     .attr('stroke-width', d => d.id === rootSubject ? 3 : 1)
-    .style('cursor', 'grab')
+    .style('cursor', 'default') // Changed from 'grab' to 'default'
     .on('mouseover', function(event, d) {
       console.log('Node rect hover:', d);
       
@@ -3617,29 +3612,6 @@ function wrapText(text, maxChars) {
   return lines;
 }
 
-// Drag functions for nodes
-function dragStarted(event, d) {
-  if (!event.active) simulation.alphaTarget(0.3).restart();
-  d.fx = d.x;
-  d.fy = d.y;
-  d3.select(this).select('rect').style('cursor', 'grabbing');
-}
-
-function dragged(event, d) {
-  d.fx = event.x;
-  d.fy = event.y;
-}
-
-function dragEnded(event, d) {
-  if (!event.active) simulation.alphaTarget(0);
-  // Keep root node fixed, release others
-  if (d.id !== rootSubject) {
-    d.fx = null;
-    d.fy = null;
-  }
-  d3.select(this).select('rect').style('cursor', 'grab');
-}
-
 // Function to zoom to fit all nodes
 function zoomToFitAll() {
   // Get the bounds of all nodes
@@ -3676,6 +3648,8 @@ function zoomToFitAll() {
     d3.zoomIdentity.translate(translateX, translateY).scale(scale)
   );
 }
+
+// Remove drag functions since we disabled node dragging
 
 function buildGraph(subject, filterKeywords = []) {
   // Update page title with subject name

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741012586">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741012586">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741018182">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741018182">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -43,16 +43,16 @@ $(document).ready(function() {
 <meta property="og:locale" content="en_US" />
 <meta name="description" content="Tracking where the money goes" />
 <meta property="og:description" content="Tracking where the money goes" />
-<link rel="canonical" href="https://datarepublican.com/relations/" />
-<meta property="og:url" content="https://datarepublican.com/relations/" />
+<link rel="canonical" href="http://localhost:4000/relations/" />
+<meta property="og:url" content="http://localhost:4000/relations/" />
 <meta property="og:site_name" content="DataRepublican" />
-<meta property="og:image" content="https://datarepublican.com/assets/images/og-3-1.png" />
+<meta property="og:image" content="http://localhost:4000/assets/images/og-3-1.png" />
 <meta property="og:type" content="website" />
 <meta name="twitter:card" content="summary_large_image" />
-<meta property="twitter:image" content="https://datarepublican.com/assets/images/og-3-1.png" />
+<meta property="twitter:image" content="http://localhost:4000/assets/images/og-3-1.png" />
 <meta property="twitter:title" content="People Relations (BETA)" />
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"WebPage","description":"Tracking where the money goes","headline":"People Relations (BETA)","image":"https://datarepublican.com/assets/images/og-3-1.png","url":"https://datarepublican.com/relations/"}</script>
+{"@context":"https://schema.org","@type":"WebPage","description":"Tracking where the money goes","headline":"People Relations (BETA)","image":"http://localhost:4000/assets/images/og-3-1.png","url":"http://localhost:4000/relations/"}</script>
 <!-- End Jekyll SEO tag -->
 
 </head>
@@ -744,9 +744,8 @@ $(document).ready(function() {
       <!-- jQuery for convenience -->
 <script src="jquery.min.js"></script>
 
-<!-- Viz.js (core + full render) -->
-<script src="viz.js"></script>
-<script src="full.render.js"></script>
+<!-- D3.js -->
+<script src="https://d3js.org/d3.v7.min.js"></script>
 
 <!-- svg-pan-zoom for panning/zooming the resulting SVG -->
 <script src="svg-pan-zoom.min.js"></script>
@@ -785,6 +784,56 @@ $(document).ready(function() {
     gap: 8px;
     margin-bottom: 0.5rem;
   }
+  
+  /* D3 Graph Styles */
+  .node rect {
+    fill: #F3F4F6;
+    stroke: #94A3B8;
+    stroke-width: 1px;
+    filter: drop-shadow(0px 2px 3px rgba(0, 0, 0, 0.1));
+  }
+  .node.root rect {
+    stroke: #2563EB;
+    stroke-width: 3px;
+    fill: #EFF6FF;
+  }
+  .node text {
+    pointer-events: none;
+  }
+  .link {
+    fill: none;
+    stroke: #CBD5E1;
+    stroke-width: 2px;
+    filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.05));
+  }
+  .arrow-path {
+    fill: #CBD5E1;
+  }
+  .label-bg {
+    fill: #F3F4F6;
+    stroke: white;
+    stroke-width: 2px;
+    filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.1));
+  }
+  .link-label {
+    fill: #475569;
+    font-size: 12px;
+    text-anchor: middle;
+    pointer-events: none;
+  }
+  .legend-item {
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    color: white;
+    margin-right: 4px;
+    margin-bottom: 4px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  }
+  .legend-item.disabled {
+    opacity: 0.5;
+  }
 </style>
 
 <!-- 
@@ -807,7 +856,7 @@ letting the user enter a name, see results, and click to load GraphViz mode.
   <form id="searchForm" class="flex flex-wrap gap-2 items-end">
     <div>
       <label for="searchBox" class="text-sm font-bold mb-1">Name/Keyword(s)</label><br/>
-      <input type="text" id="searchBox" class="border border-gray-200 rounded p-2 w-full" placeholder="E.g. ‘aaron’ or ‘14th Dalai Lama’"/>
+      <input type="text" id="searchBox" class="border border-gray-200 rounded p-2 w-full" placeholder="E.g. 'aaron' or '14th Dalai Lama'"/>
     </div>
 
     <button type="submit" id="searchButton" class="p-2 border border-gray-200 rounded font-bold text-sm">
@@ -843,9 +892,9 @@ It shows the generated graph and a legend, plus a button to go back to the searc
 <div id="graphExplanation" class="mb-3">
   <h1 id="graphTitle" class="mb-1">Relationship Graph</h1>
   <p class="text-sm mb-2" id="graphInstructions">
-    Below is a visualization of our selected subject’s relationships, color-coded by category.  
+    Below is a visualization of our selected subject's relationships, color-coded by category.  
     <strong>Click any color</strong> in the legend below to toggle that category on/off. The graph will re-render automatically.  
-    Click “Download SVG” to get an offline copy of the image.
+    Click "Download SVG" to get an offline copy of the image.
   </p>
 </div>
 
@@ -857,7 +906,17 @@ It shows the generated graph and a legend, plus a button to go back to the searc
 
 <!-- Where the graph renders -->
 <div id="graph-container" class="border rounded flex items-center justify-center bg-white">
-  <div>
+  <svg id="graph" width="100%" height="100%">
+    <!-- Arrow marker definition for edges -->
+    <defs>
+      <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+        markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-path" />
+      </marker>
+    </defs>
+    <g id="graph-content"></g>
+  </svg>
+  <div id="loading-indicator" class="absolute">
     <img src="../assets/images/loading.svg" class="loading-spinner" style="width:32px;height:32px" alt="Loading...">
   </div>
 </div>
@@ -895,13 +954,31 @@ let categoryColors = {
   "UNKNOWN": "#6B7280"
 };
 
-let panZoomInstance = null;
+// D3 Graph variables
+let width, height;
+let simulation = null;
+let zoom = null;
+let nodeElements = null;
+let linkElements = null;
+let labelElements = null;
 
 // We store all graph edges in memory so toggling categories is easy:
 let globalNodesMap = new Map();  // subject -> bullet info
 let globalAllEdges = [];         // all edges (including duplicates filtered out)
 let globalActiveCategories = new Set(); // which categories are currently on display
 
+// Force simulation parameters
+const forceParams = {
+  linkDistance: 400,
+  charge: -3000,
+  collisionRadius: 200,
+  bounds: {
+    left: 100,
+    right: 100,
+    top: 100,
+    bottom: 100
+  }
+};
 
 /***************************************
 * ON LOAD
@@ -1208,10 +1285,9 @@ $('#backToSearch').on('click', function() {
 * GRAPH MODE
 ***************************************/
 async function renderGraphForSubject(subjectName) {
-  // Show spinner in #graph-container
-  $('#graph-container').html(`
-    <div><img src="../assets/images/loading.svg" style="width:32px;height:32px" alt="Loading..."></div>
-  `);
+  // Show loading indicator
+  $('#loading-indicator').show();
+  $('#graph-content').empty();
 
   // Set the search param in the URL
   const newUrl = new URL(window.location);
@@ -1238,6 +1314,9 @@ async function renderGraphForSubject(subjectName) {
   globalAllEdges = [];
   globalActiveCategories.clear();
 
+  // Initialize D3 graph
+  initializeD3Graph();
+
   // Add the root node
   addNodeIfNeeded(globalNodesMap, subjectName);
 
@@ -1247,12 +1326,28 @@ async function renderGraphForSubject(subjectName) {
   const relationsZip = `relations_${pStr}.zip`;
 
   try {
+    // Show loading status
+    $('#graphInstructions').html(`
+      <div class="flex items-center gap-2">
+        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
+        <span>Loading relationship data for ${escapeHtml(subjectName)}...</span>
+      </div>
+    `);
+
     const resp = await fetch(relationsZip);
     if (!resp.ok) {
       throw new Error(`Unable to fetch ${relationsZip}`);
     }
     const buffer = await resp.arrayBuffer();
     const z = await JSZip.loadAsync(buffer);
+
+    // Update loading status
+    $('#graphInstructions').html(`
+      <div class="flex items-center gap-2">
+        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
+        <span>Parsing relationship data...</span>
+      </div>
+    `);
 
     // parse relations.csv, relations_reverse.csv, intergraph_edges.csv
     const relationsCsv     = await getZipText(z, 'relations.csv');
@@ -1262,6 +1357,14 @@ async function renderGraphForSubject(subjectName) {
     const parsedRelations  = Papa.parse(relationsCsv,     { header:true, skipEmptyLines:true }).data;
     const parsedReverse    = Papa.parse(revCsv,           { header:true, skipEmptyLines:true }).data;
     const parsedIntergraph = Papa.parse(interCsv,         { header:true, skipEmptyLines:true }).data;
+
+    // Update loading status
+    $('#graphInstructions').html(`
+      <div class="flex items-center gap-2">
+        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
+        <span>Building relationship graph...</span>
+      </div>
+    `);
 
     let edgesSet = new Set(); // to ensure no duplicates
 
@@ -1348,23 +1451,63 @@ async function renderGraphForSubject(subjectName) {
     // Render the legend
     renderLegend([...uniqueCats]);
 
-    // Build and render final
-    reRenderGraph(subjectName);
+    // Update loading status
+    $('#graphInstructions').html(`
+      <div class="flex items-center gap-2">
+        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
+        <span>Rendering graph with ${globalNodesMap.size} nodes and ${globalAllEdges.length} connections...</span>
+      </div>
+    `);
+
+    // Prepare data for D3
+    const nodes = [];
+    const edges = [];
+    
+    // Add nodes
+    for (let [subject, bulletInfo] of globalNodesMap.entries()) {
+      nodes.push({
+        id: subject,
+        bulletInfo: bulletInfo
+      });
+    }
+    
+    // Add edges
+    for (let edge of globalAllEdges) {
+      edges.push({
+        source: edge.from,
+        target: edge.to,
+        from: edge.from,
+        to: edge.to,
+        label: edge.label,
+        category: edge.category,
+        color: edge.color
+      });
+    }
+    
+    // Render the D3 graph
+    renderD3Graph(subjectName, nodes, edges);
+
+    // Restore instructions
+    setTimeout(() => {
+      $('#graphInstructions').html(`
+        Below is a visualization of our selected subject's relationships, color-coded by category.  
+        <strong>Click any color</strong> in the legend below to toggle that category on/off. The graph will re-render automatically.  
+        Click "Download SVG" to get an offline copy of the image.
+      `);
+    }, 1000);
 
   } catch (err) {
     console.error(err);
     $('#graph-container').html(
       `<div class="p-2 text-center text-sm text-red-500">Error loading relationships: ${err}</div>`
     );
+    $('#graphInstructions').html(`
+      <div class="text-red-500">Error: ${escapeHtml(err.message)}</div>
+    `);
   }
 }
 
 // Build & render the DOT from globalNodesMap + filtered edges
-function reRenderGraph(rootSubject) {
-  let activeEdges = globalAllEdges.filter(e => globalActiveCategories.has(e.category));
-  let dotSrc = buildDotSource(rootSubject, globalNodesMap, activeEdges);
-  renderDot(dotSrc);
-}
 
 // A function to ensure node exists
 function addNodeIfNeeded(map, subject) {
@@ -1397,28 +1540,6 @@ async function getZipText(zipObj, filename) {
 
 
 /***************************************
-* DOT BUILDING / RENDERING
-***************************************/
-// We insert <br> every ~50 chars on word boundaries
-function insertLineBreaks(str, maxLen=50) {
-  if (!str) return '';
-  const words = str.split(/\s+/);
-  let lines = [];
-  let current = '';
-
-  for (let w of words) {
-    if (!current) {
-      current = w;
-    } else if ((current + ' ' + w).length > maxLen) {
-      lines.push(escapeHtml(current));
-      current = w;
-    } else {
-      current += ' ' + w;
-    }
-  }
-  if (current) lines.push(escapeHtml(current));
-  return lines.join("<BR/>");
-}
 
 function buildDotSource(rootSubject, nodesMap, edges) {
   let dot = `digraph G {
@@ -1499,8 +1620,8 @@ function renderLegend(categories) {
   let html = '';
   categories.sort(); // optional: sort them alphabetically
   for (let c of categories) {
-    let colorClass = 'legend-' + c;
-    html += `<div class="legend-item ${colorClass}" data-cat="${c}">${c}</div>`;
+    let color = categoryColors[c] || categoryColors["UNKNOWN"];
+    html += `<div class="legend-item" data-cat="${c}" style="background-color: ${color};">${c}</div>`;
   }
   $('#legend').html(html);
 
@@ -1519,9 +1640,19 @@ function toggleCategory(cat) {
   } else {
     globalActiveCategories.add(cat);
   }
-  // re-render
-  let rootName = $('#graphTitle').text().trim();
-  reRenderGraph(rootName);
+  
+  // Filter edges based on active categories
+  const activeEdges = globalAllEdges.filter(e => globalActiveCategories.has(e.category));
+  
+  // Update edge visibility
+  linkElements.attr('visibility', d => 
+    globalActiveCategories.has(d.category) ? 'visible' : 'hidden'
+  );
+  
+  // Update label visibility
+  labelElements.attr('visibility', d => 
+    globalActiveCategories.has(d.category) ? 'visible' : 'hidden'
+  );
 }
 
 
@@ -1529,14 +1660,29 @@ function toggleCategory(cat) {
 * DOWNLOAD SVG
 ***************************************/
 $('#downloadBtn').on('click', function() {
-  let svgEl = document.querySelector('#graph-container svg');
+  const svgEl = document.querySelector('#graph');
   if (!svgEl) {
     alert('No SVG to download');
     return;
   }
-  let svgData = new XMLSerializer().serializeToString(svgEl);
-  let blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
-  let url = URL.createObjectURL(blob);
+  
+  // Create a clone of the SVG to modify for download
+  const clonedSvg = svgEl.cloneNode(true);
+  
+  // Set explicit width and height
+  clonedSvg.setAttribute('width', width);
+  clonedSvg.setAttribute('height', height);
+  
+  // Reset the transform to ensure the graph is centered
+  const content = clonedSvg.querySelector('#graph-content');
+  if (content) {
+    content.setAttribute('transform', `translate(${width/2}, ${height/2})`);
+  }
+  
+  // Convert to string
+  const svgData = new XMLSerializer().serializeToString(clonedSvg);
+  const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
 
   let link = document.createElement('a');
   link.href = url;
@@ -1558,6 +1704,534 @@ function escapeHtml(str) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
+}
+
+/***************************************
+* D3 GRAPH RENDERING
+***************************************/
+function initializeD3Graph() {
+  // Get container dimensions
+  const container = document.getElementById('graph-container');
+  width = container.clientWidth;
+  height = container.clientHeight;
+  
+  // Initialize zoom behavior
+  zoom = d3.zoom()
+    .scaleExtent([0.1, 2])
+    .on('zoom', (event) => {
+      d3.select('#graph-content').attr('transform', event.transform);
+    });
+  
+  // Apply zoom behavior to SVG
+  d3.select('#graph')
+    .call(zoom)
+    .on('dblclick.zoom', null); // Disable double-click zoom
+    
+  // Reset zoom and pan
+  resetZoom();
+  
+  // Show loading indicator
+  $('#loading-indicator').show();
+}
+
+function resetZoom() {
+  d3.select('#graph').call(
+    zoom.transform,
+    d3.zoomIdentity.translate(width/2, height/2)
+  );
+}
+
+function renderD3Graph(rootSubject, nodes, edges) {
+  // Clear previous graph
+  d3.select('#graph-content').selectAll('*').remove();
+  
+  // Hide loading indicator when rendering starts
+  $('#loading-indicator').hide();
+  
+  // Create the graph content group
+  const g = d3.select('#graph-content');
+  
+  // Create links
+  linkElements = g.append('g')
+    .attr('class', 'links')
+    .selectAll('path')
+    .data(edges)
+    .join('path')
+    .attr('class', 'link')
+    .attr('stroke', d => d.color)
+    .attr('stroke-width', 2)
+    .attr('marker-end', 'url(#arrow)');
+  
+  // Create nodes
+  nodeElements = g.append('g')
+    .attr('class', 'nodes')
+    .selectAll('g')
+    .data(nodes)
+    .join('g')
+    .attr('class', d => d.id === rootSubject ? 'node root' : 'node')
+    .attr('data-id', d => d.id)
+    .call(d3.drag()
+      .on('start', dragStarted)
+      .on('drag', dragged)
+      .on('end', dragEnded)
+    );
+  
+  // Add rectangles to nodes
+  nodeElements.append('rect')
+    .attr('rx', 4)
+    .attr('ry', 4)
+    .attr('width', d => getNodeWidth(d))
+    .attr('height', d => getNodeHeight(d))
+    .style('cursor', 'grab');
+  
+  // Add text to nodes
+  nodeElements.each(function(d) {
+    const node = d3.select(this);
+    const bulletInfo = d.bulletInfo;
+    const padding = 10;
+    let y = padding;
+    
+    // Add subject name
+    node.append('text')
+      .attr('x', padding)
+      .attr('y', y + 15)
+      .attr('font-weight', 'bold')
+      .attr('font-size', '14px')
+      .text(d.id);
+    y += 25;
+    
+    // Add bullet point 1 if available
+    if (bulletInfo.bullet_point1) {
+      const wrappedText = wrapText(bulletInfo.bullet_point1, 30);
+      wrappedText.forEach(line => {
+        node.append('text')
+          .attr('x', padding)
+          .attr('y', y + 12)
+          .attr('font-size', '12px')
+          .text(line);
+        y += 18;
+      });
+    }
+    
+    // Add bullet point 2 if available
+    if (bulletInfo.bullet_point2) {
+      y += 5; // Add a little extra space
+      const wrappedText = wrapText(bulletInfo.bullet_point2, 30);
+      wrappedText.forEach(line => {
+        node.append('text')
+          .attr('x', padding)
+          .attr('y', y + 12)
+          .attr('font-size', '12px')
+          .text(line);
+        y += 18;
+      });
+    }
+  });
+  
+  // Create edge labels
+  const labelGroup = g.append('g').attr('class', 'label-group');
+  labelElements = labelGroup.selectAll('g')
+    .data(edges)
+    .join('g')
+    .attr('class', 'link-label-group');
+  
+  // Add background pill for labels
+  labelElements.append('rect')
+    .attr('rx', 12)
+    .attr('ry', 12)
+    .attr('class', 'label-bg')
+    .style('cursor', 'pointer')
+    .on('mouseover', function(event, d) {
+      d3.select(this).attr('fill', d.color);
+      d3.select(this.parentNode).select('.link-label').attr('fill', 'white');
+      linkElements.filter(l => l === d).attr('stroke-width', 4);
+    })
+    .on('mouseout', function() {
+      d3.select(this).attr('fill', '#F3F4F6');
+      d3.select(this.parentNode).select('.link-label').attr('fill', '#475569');
+      linkElements.attr('stroke-width', 2);
+    });
+  
+  // Add text labels with wrapping
+  labelElements.each(function(d) {
+    const labelGroup = d3.select(this);
+    const label = d.label || "";
+    
+    // Skip empty labels
+    if (!label.trim()) {
+      labelGroup.append('text')
+        .attr('class', 'link-label')
+        .text("");
+      return;
+    }
+    
+    // Wrap text to max 20 characters per line
+    const wrappedText = wrapText(label, 20);
+    
+    // Add each line of text
+    wrappedText.forEach((line, i) => {
+      labelGroup.append('text')
+        .attr('class', 'link-label')
+        .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
+        .text(line);
+    });
+  });
+  
+  // Add hover effects to nodes
+  nodeElements.on('mouseover', function(event, d) {
+    // Highlight this node
+    d3.select(this).select('rect')
+      .attr('stroke-width', 3)
+      .attr('stroke', '#2563EB');
+    
+    // Highlight connected edges and nodes
+    linkElements.each(function(link) {
+      if (link.from === d.id || link.to === d.id) {
+        d3.select(this)
+          .attr('stroke-width', 4)
+          .attr('stroke', link.color);
+        
+        // Highlight connected node
+        const connectedId = link.from === d.id ? link.to : link.from;
+        nodeElements.filter(n => n.id === connectedId)
+          .select('rect')
+          .attr('stroke-width', 2)
+          .attr('stroke', link.color);
+      }
+    });
+    
+    // Highlight related labels
+    labelElements.each(function(label) {
+      if (label.from === d.id || label.to === d.id) {
+        d3.select(this).select('.label-bg')
+          .attr('fill', label.color);
+        d3.select(this).select('.link-label')
+          .attr('fill', 'white');
+      }
+    });
+  })
+  .on('mouseout', function() {
+    // Reset node styles
+    nodeElements.select('rect')
+      .attr('stroke-width', d => d.id === rootSubject ? 3 : 1)
+      .attr('stroke', d => d.id === rootSubject ? '#2563EB' : '#94A3B8');
+    
+    // Reset edge styles
+    linkElements
+      .attr('stroke-width', 2)
+      .attr('stroke', d => d.color);
+    
+    // Reset label styles
+    labelElements.select('.label-bg')
+      .attr('fill', '#F3F4F6');
+    labelElements.select('.link-label')
+      .attr('fill', '#475569');
+  });
+  
+  // Start the simulation
+  simulation = d3.forceSimulation(nodes)
+    .force('link', d3.forceLink(edges)
+      .id(d => d.id)
+      .distance(d => {
+        // Adjust link distance based on node sizes
+        const sourceNode = nodes.find(n => n.id === d.from);
+        const targetNode = nodes.find(n => n.id === d.to);
+        if (!sourceNode || !targetNode) return forceParams.linkDistance;
+        
+        const sourceSize = Math.sqrt(getNodeWidth(sourceNode) * getNodeHeight(sourceNode));
+        const targetSize = Math.sqrt(getNodeWidth(targetNode) * getNodeHeight(targetNode));
+        
+        // Base distance on node sizes plus padding
+        return (sourceSize + targetSize) / 2 + forceParams.linkDistance;
+      }))
+    .force('charge', d3.forceManyBody()
+      .strength(d => {
+        // Adjust repulsion based on node size
+        const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
+        return forceParams.charge * (nodeSize / 200);
+      })
+      .distanceMin(150)
+      .distanceMax(2000))
+    .force('center', d3.forceCenter(width / 2, height / 2))
+    .force('x', d3.forceX(width / 2).strength(0.05))
+    .force('y', d3.forceY(height / 2).strength(0.05))
+    .force('collision', d3.forceCollide().radius(d => {
+      // Make collision radius based on node size plus padding
+      const nodeWidth = getNodeWidth(d);
+      const nodeHeight = getNodeHeight(d);
+      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 50;
+    }).strength(1))
+    .alpha(0.6)
+    .alphaDecay(0.01) // Slower decay for more time to find optimal positions
+    .velocityDecay(0.4) // Lower value to allow nodes to move more freely
+    .on('tick', ticked);
+  
+  // Enable download button
+  $('#downloadBtn').show();
+  
+  // Auto-zoom to fit all nodes after simulation stabilizes
+  setTimeout(() => {
+    zoomToFitAll();
+  }, 2000);
+}
+
+// Function to zoom to fit all nodes
+function zoomToFitAll() {
+  if (!nodeElements || !nodeElements.size()) return;
+  
+  // Get bounding box of all nodes
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  
+  nodeElements.each(function(d) {
+    const nodeWidth = getNodeWidth(d);
+    const nodeHeight = getNodeHeight(d);
+    
+    minX = Math.min(minX, d.x - nodeWidth/2);
+    minY = Math.min(minY, d.y - nodeHeight/2);
+    maxX = Math.max(maxX, d.x + nodeWidth/2);
+    maxY = Math.max(maxY, d.y + nodeHeight/2);
+  });
+  
+  // Add padding
+  const padding = 50;
+  minX -= padding;
+  minY -= padding;
+  maxX += padding;
+  maxY += padding;
+  
+  const graphWidth = maxX - minX;
+  const graphHeight = maxY - minY;
+  
+  // Calculate scale to fit
+  const scale = Math.min(
+    width / graphWidth,
+    height / graphHeight,
+    1.5 // Max scale
+  );
+  
+  // Calculate center point
+  const centerX = minX + graphWidth/2;
+  const centerY = minY + graphHeight/2;
+  
+  // Apply zoom transform
+  d3.select('#graph').transition()
+    .duration(750)
+    .call(
+      zoom.transform,
+      d3.zoomIdentity
+        .translate(width/2, height/2)
+        .scale(scale)
+        .translate(-centerX, -centerY)
+    );
+}
+
+function ticked() {
+  // Update node positions
+  nodeElements.attr('transform', d => {
+    // Constrain to bounds
+    d.x = Math.max(forceParams.bounds.left, Math.min(width - forceParams.bounds.right, d.x));
+    d.y = Math.max(forceParams.bounds.top, Math.min(height - forceParams.bounds.bottom, d.y));
+    return `translate(${d.x - getNodeWidth(d) / 2}, ${d.y - getNodeHeight(d) / 2})`;
+  });
+  
+  // Update link paths
+  linkElements.attr('d', d => {
+    const sourceNode = nodeElements.filter(n => n.id === d.from).datum();
+    const targetNode = nodeElements.filter(n => n.id === d.to).datum();
+    
+    if (!sourceNode || !targetNode) return '';
+    
+    const sourceWidth = getNodeWidth(sourceNode);
+    const sourceHeight = getNodeHeight(sourceNode);
+    const targetWidth = getNodeWidth(targetNode);
+    const targetHeight = getNodeHeight(targetNode);
+    
+    // Calculate source and target points on the edges of the rectangles
+    const sourceX = sourceNode.x;
+    const sourceY = sourceNode.y;
+    const targetX = targetNode.x;
+    const targetY = targetNode.y;
+    
+    // Find intersection points with rectangles
+    const sourcePoint = findIntersectionPoint(
+      sourceX, sourceY, targetX, targetY,
+      sourceX - sourceWidth/2, sourceY - sourceHeight/2,
+      sourceWidth, sourceHeight
+    );
+    
+    const targetPoint = findIntersectionPoint(
+      targetX, targetY, sourceX, sourceY,
+      targetX - targetWidth/2, targetY - targetHeight/2,
+      targetWidth, targetHeight
+    );
+    
+    if (!sourcePoint || !targetPoint) return '';
+    
+    // Add a slight curve to the path to make overlapping paths more visible
+    const dx = targetPoint.x - sourcePoint.x;
+    const dy = targetPoint.y - sourcePoint.y;
+    const dr = Math.sqrt(dx * dx + dy * dy) * 1.2;
+    
+    // Use curved paths for better visibility when there are multiple edges
+    return `M${sourcePoint.x},${sourcePoint.y} A${dr},${dr} 0 0,1 ${targetPoint.x},${targetPoint.y}`;
+  });
+  
+  // Update label positions
+  labelElements.attr('transform', d => {
+    const path = linkElements.filter(l => l === d).node();
+    if (!path) return '';
+    
+    const pathLength = path.getTotalLength();
+    if (isNaN(pathLength) || pathLength === 0) return '';
+    
+    // Position label at the midpoint of the path
+    const midPoint = path.getPointAtLength(pathLength / 2);
+    return `translate(${midPoint.x}, ${midPoint.y})`;
+  });
+  
+  // Update label background sizes
+  labelElements.each(function(d) {
+    const labelTexts = d3.select(this).selectAll('.link-label');
+    if (!labelTexts.size()) return;
+    
+    // Calculate bounding box that encompasses all text elements
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    
+    labelTexts.each(function() {
+      const bbox = this.getBBox();
+      minX = Math.min(minX, bbox.x);
+      minY = Math.min(minY, bbox.y);
+      maxX = Math.max(maxX, bbox.x + bbox.width);
+      maxY = Math.max(maxY, bbox.y + bbox.height);
+    });
+    
+    // Add padding
+    const padding = { x: 10, y: 6 };
+    
+    d3.select(this).select('.label-bg')
+      .attr('x', minX - padding.x)
+      .attr('y', minY - padding.y)
+      .attr('width', maxX - minX + padding.x * 2)
+      .attr('height', maxY - minY + padding.y * 2);
+  });
+}
+
+function dragStarted(event, d) {
+  if (!event.active) simulation.alphaTarget(0.3).restart();
+  d.fx = d.x;
+  d.fy = d.y;
+  d3.select(this).style('cursor', 'grabbing');
+}
+
+function dragged(event, d) {
+  d.fx = event.x;
+  d.fy = event.y;
+}
+
+function dragEnded(event, d) {
+  if (!event.active) simulation.alphaTarget(0);
+  d.fx = null;
+  d.fy = null;
+  d3.select(this).style('cursor', 'grab');
+}
+
+function getNodeWidth(d) {
+  // Calculate width based on text content
+  const minWidth = 200;
+  const textLength = d.id.length;
+  const bulletLength1 = d.bulletInfo?.bullet_point1?.length || 0;
+  const bulletLength2 = d.bulletInfo?.bullet_point2?.length || 0;
+  const maxTextLength = Math.max(textLength, bulletLength1 / 5, bulletLength2 / 5);
+  return Math.max(minWidth, maxTextLength * 7);
+}
+
+function getNodeHeight(d) {
+  // Calculate height based on text content
+  const baseHeight = 50; // Minimum height
+  const bulletInfo = d.bulletInfo;
+  let additionalHeight = 0;
+  
+  if (bulletInfo.bullet_point1) {
+    const lines1 = Math.ceil(bulletInfo.bullet_point1.length / 30);
+    additionalHeight += lines1 * 18;
+  }
+  
+  if (bulletInfo.bullet_point2) {
+    const lines2 = Math.ceil(bulletInfo.bullet_point2.length / 30);
+    additionalHeight += lines2 * 18 + 5; // +5 for spacing
+  }
+  
+  return baseHeight + additionalHeight;
+}
+
+function wrapText(text, maxCharsPerLine) {
+  if (!text) return [];
+  
+  const words = text.split(' ');
+  const lines = [];
+  let currentLine = '';
+  
+  words.forEach(word => {
+    const testLine = currentLine ? `${currentLine} ${word}` : word;
+    if (testLine.length <= maxCharsPerLine) {
+      currentLine = testLine;
+    } else {
+      lines.push(currentLine);
+      currentLine = word;
+    }
+  });
+  
+  if (currentLine) {
+    lines.push(currentLine);
+  }
+  
+  return lines;
+}
+
+function findIntersectionPoint(x1, y1, x2, y2, rectX, rectY, rectWidth, rectHeight) {
+  // Calculate rectangle corners
+  const corners = [
+    { x: rectX, y: rectY }, // top-left
+    { x: rectX + rectWidth, y: rectY }, // top-right
+    { x: rectX + rectWidth, y: rectY + rectHeight }, // bottom-right
+    { x: rectX, y: rectY + rectHeight } // bottom-left
+  ];
+  
+  // Check intersection with each edge of the rectangle
+  const edges = [
+    [corners[0], corners[1]], // top
+    [corners[1], corners[2]], // right
+    [corners[2], corners[3]], // bottom
+    [corners[3], corners[0]]  // left
+  ];
+  
+  for (const [p1, p2] of edges) {
+    const intersection = lineIntersection(x1, y1, x2, y2, p1.x, p1.y, p2.x, p2.y);
+    if (intersection) {
+      return intersection;
+    }
+  }
+  
+  // If no intersection found, return center of rectangle
+  return { x: rectX + rectWidth / 2, y: rectY + rectHeight / 2 };
+}
+
+function lineIntersection(x1, y1, x2, y2, x3, y3, x4, y4) {
+  // Calculate determinants
+  const den = (y4 - y3) * (x2 - x1) - (x4 - x3) * (y2 - y1);
+  if (den === 0) return null; // Lines are parallel
+  
+  const ua = ((x4 - x3) * (y1 - y3) - (y4 - y3) * (x1 - x3)) / den;
+  const ub = ((x2 - x1) * (y1 - y3) - (y2 - y1) * (x1 - x3)) / den;
+  
+  // Check if intersection is on both line segments
+  if (ua < 0 || ua > 1 || ub < 0 || ub > 1) return null;
+  
+  // Calculate intersection point
+  const x = x1 + ua * (x2 - x1);
+  const y = y1 + ua * (y2 - y1);
+  
+  return { x, y };
 }
 </script>
 

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741045261">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741045261">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741045436">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741045436">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -1064,9 +1064,9 @@ let globalActiveCategories = new Set(); // which categories are currently on dis
 
 // Force simulation parameters
 const forceParams = {
-  linkDistance: 1200,     // Doubled from 600
-  charge: -10000,         // Doubled from -5000
-  collisionRadius: 500,   // Increased from 300
+  linkDistance: 800,     // Reduced from 1200
+  charge: -8000,         // Reduced from -10000
+  collisionRadius: 400,   // Reduced from 500
   bounds: {
     left: 300,
     right: 300,
@@ -2481,7 +2481,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .stop();
   
   // Run the pre-positioning simulation for more iterations
-  for (let i = 0; i < 150; i++) {
+  for (let i = 0; i < 50; i++) {  // Reduced from 150 to 50 iterations
     tempSimulation.tick();
   }
   
@@ -2493,59 +2493,59 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .distance(d => {
         // Use different distances for different types of connections
         if (d.from === rootSubject || d.to === rootSubject) {
-          return forceParams.linkDistance * 10; // More space for root connections
+          return forceParams.linkDistance * 8; // Reduced from 10
         }
-        return forceParams.linkDistance * 7; // More space for non-root connections
+        return forceParams.linkDistance * 5; // Reduced from 7
       }))
     .force('charge', d3.forceManyBody()
       .strength(d => {
         // Use stronger repulsion for the root
         if (d.id === rootSubject) {
-          return forceParams.charge * -20;
+          return forceParams.charge * -15; // Reduced from -20
         }
         // Use node size to scale repulsion
         const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
-        return forceParams.charge * (nodeSize / 150) * -15;
+        return forceParams.charge * (nodeSize / 150) * -10; // Reduced from -15
       })
-      .distanceMin(900)
-      .distanceMax(12000))
+      .distanceMin(600) // Reduced from 900
+      .distanceMax(8000)) // Reduced from 12000
     .force('x', d3.forceX(d => {
       // Root node stays at center
       if (d.id === rootSubject) return 0;
       
       // First level nodes maintain their existing x position but with scaling
       if (firstLevelNodeIds.has(d.id)) {
-        return d.x * 1.3; // Expand the first level more
+        return d.x * 1.2; // Reduced from 1.3
       }
       
       // Second level nodes spread wider
-      return d.x * 1.4;
-    }).strength(d => d.id === rootSubject ? 1 : 0.2))
+      return d.x * 1.3; // Reduced from 1.4
+    }).strength(d => d.id === rootSubject ? 1 : 0.3)) // Increased from 0.2 for faster positioning
     .force('y', d3.forceY(d => {
       // Keep root at top
-      if (d.id === rootSubject) return -height * 0.4;
+      if (d.id === rootSubject) return -height * 0.3; // Reduced from 0.4
       
       // First level nodes position
       if (firstLevelNodeIds.has(d.id)) {
-        return d.y * 0.95; // Keep in their semi-circle but slightly tighter
+        return d.y * 0.9; // Adjust as needed
       }
       
       // Second level nodes position
-      return d.y * 1.3; // Push further down
-    }).strength(d => d.id === rootSubject ? 1 : 0.35))
+      return d.y * 1.2; // Reduced from 1.3
+    }).strength(d => d.id === rootSubject ? 1 : 0.4)) // Increased from 0.35
     .force('collision', d3.forceCollide().radius(d => {
       // Use much larger collision radius
       const nodeWidth = getNodeWidth(d);
       const nodeHeight = getNodeHeight(d);
       // Different collision radii based on node type
       if (d.id === rootSubject) {
-        return Math.sqrt(nodeWidth * nodeHeight) + 180;
+        return Math.sqrt(nodeWidth * nodeHeight) + 150; // Reduced from 180
       }
-      return Math.sqrt(nodeWidth * nodeHeight) + 130;
-    }).strength(0.95).iterations(4)) // More iterations for better collision resolution
-    .alpha(0.4) // Start with lower alpha since we've pre-positioned
-    .alphaDecay(0.003) // Slower decay for more gradual layout
-    .velocityDecay(0.25) // Adjust velocity decay for smoother movement
+      return Math.sqrt(nodeWidth * nodeHeight) + 100; // Reduced from 130
+    }).strength(0.8).iterations(2)) // Reduced iterations from 4 to 2
+    .alpha(0.5) // Slightly higher alpha for faster convergence
+    .alphaDecay(0.015) // Increased from 0.003 for faster convergence
+    .velocityDecay(0.3) // Increased from 0.25 for slightly more damping
     .on('tick', ticked)
     .on('end', () => {
       // When the simulation ends, center the graph based on actual content bounds

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741033671">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741033671">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741034775">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741034775">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -802,12 +802,8 @@ $(document).ready(function() {
   }
   .link {
     fill: none;
-    stroke: #CBD5E1;
     stroke-width: 2px;
     filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.05));
-  }
-  .arrow-path {
-    fill: #CBD5E1;
   }
   .label-bg {
     fill: #F3F4F6;
@@ -867,8 +863,8 @@ $(document).ready(function() {
     fill: #94A3B8;
   }
   
-  #arrow-highlighted .arrow-path {
-    fill: #2563EB !important;
+  #arrow .arrow-path {
+    fill: #94A3B8;
   }
   
   /* Label styling */
@@ -990,12 +986,9 @@ It shows the generated graph and a legend, plus a button to go back to the searc
     <defs>
       <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
         markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-        <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-path" fill="#94A3B8" />
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#94A3B8" />
       </marker>
-      <marker id="arrow-highlighted" viewBox="0 0 10 10" refX="5" refY="5"
-        markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-        <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-path" fill="#2563EB" />
-      </marker>
+      <!-- Category-specific markers will be added dynamically by D3 -->
     </defs>
     <g id="graph-content"></g>
   </svg>
@@ -1952,28 +1945,15 @@ function renderD3Graph(rootSubject, nodes, edges) {
   defs.append('marker')
     .attr('id', 'arrow')
     .attr('viewBox', '0 -5 10 10')
-    .attr('refX', 20) // Increased to move arrow away from node
+    .attr('refX', 20)
     .attr('refY', 0)
-    .attr('markerWidth', 8) // Increased size
-    .attr('markerHeight', 8) // Increased size
+    .attr('markerWidth', 8)
+    .attr('markerHeight', 8)
     .attr('orient', 'auto')
     .append('path')
-    .attr('class', 'arrow-path')
+    .attr('fill', '#94A3B8')  // Default gray color
     .attr('d', 'M0,-5L10,0L0,5');
     
-  // Highlighted arrow marker (blue)
-  defs.append('marker')
-    .attr('id', 'arrow-highlighted')
-    .attr('viewBox', '0 -5 10 10')
-    .attr('refX', 20) // Increased to move arrow away from node
-    .attr('refY', 0)
-    .attr('markerWidth', 8) // Increased size
-    .attr('markerHeight', 8) // Increased size
-    .attr('orient', 'auto')
-    .append('path')
-    .attr('fill', '#2563EB')
-    .attr('d', 'M0,-5L10,0L0,5');
-  
   // Create a map of node IDs for quick lookup - make it global for other functions to use
   window.nodeMap = new Map();
   nodes.forEach(node => {
@@ -2211,30 +2191,42 @@ function renderD3Graph(rootSubject, nodes, edges) {
   
   // Helper function to highlight a connection between two nodes
   function highlightConnection(sourceId, targetId) {
-    // Highlight the link
-    linkElements.filter(l => {
-      return (l.from === sourceId && l.to === targetId);
-    })
-    .style('stroke', '#2563EB')
-    .style('stroke-width', '4px')
-    .attr('marker-end', 'url(#arrow-highlighted)');
+    // Find the link data to get its category color
+    const linkData = linkElements.filter(l => l.from === sourceId && l.to === targetId).data()[0];
     
-    // Highlight source and target nodes
-    nodeElements.filter(n => n.id === sourceId || n.id === targetId)
+    if (!linkData) {
+      console.warn(`No link found between ${sourceId} and ${targetId}`);
+      return;
+    }
+    
+    // Get the category color
+    const categoryColor = categoryColors[linkData.category] || categoryColors["UNKNOWN"];
+    
+    // Highlight the link with its category color
+    linkElements.filter(l => l.from === sourceId && l.to === targetId)
+      .style('stroke', categoryColor)
+      .style('stroke-width', '4px')
+      .attr('marker-end', `url(#arrow-${linkData.category || 'UNKNOWN'})`);
+    
+    // Highlight source and target nodes with the same category color
+    nodeElements.filter(n => n.id === sourceId)
       .select('rect')
-      .style('stroke', '#2563EB')
+      .style('stroke', '#2563EB')  // Source node still uses blue
+      .style('stroke-width', '3px');
+      
+    nodeElements.filter(n => n.id === targetId)
+      .select('rect')
+      .style('stroke', categoryColor)  // Target node uses category color
       .style('stroke-width', '3px');
     
-    // Highlight the label
-    labelElements.filter(l => {
-      return (l.from === sourceId && l.to === targetId);
-    })
-    .each(function() {
-      d3.select(this).select('.label-bg')
-        .style('fill', '#2563EB');
-      d3.select(this).selectAll('.link-label')
-        .style('fill', 'white');
-    });
+    // Highlight the label with the category color
+    labelElements.filter(l => l.from === sourceId && l.to === targetId)
+      .each(function() {
+        d3.select(this).select('.label-bg')
+          .style('fill', categoryColor);
+        d3.select(this).selectAll('.link-label')
+          .style('fill', 'white');
+      });
   }
   
   // Helper function to highlight all connections to/from a node
@@ -2260,12 +2252,13 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .attr('stroke', d => d.id === rootSubject ? '#2563EB' : '#94A3B8')
       .attr('stroke-width', d => d.id === rootSubject ? 3 : 1);
     
-    // Reset edge styles
+    // Reset edge styles - maintain category colors
     linkElements
       .style('stroke', null)
       .style('stroke-width', null)
       .attr('stroke', d => categoryColors[d.category] || categoryColors["UNKNOWN"])
-      .attr('stroke-width', 2);
+      .attr('stroke-width', 2)
+      .attr('marker-end', d => `url(#arrow-${d.category || 'UNKNOWN'})`);
     
     // Reset label styles
     labelElements.select('.label-bg')

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741046595">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741046595">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741049765">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741049765">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -1003,7 +1003,7 @@ It shows the generated graph and a legend, plus a button to go back to the searc
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
         <path fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
       </svg>
-      <div id="loading-text" class="text-lg font-semibold text-navy mb-4">Loading graph...</div>
+      <div id="loading-text" class="text-lg font-semibold text-navy">Loading data...</div>
       <div id="loading-nodes" class="text-gray-600 max-w-md mx-auto text-center px-4 max-h-[80vh] overflow-y-auto">
         <!-- Node names will be added here -->
       </div>
@@ -1976,18 +1976,36 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Position root node at the top center
   if (rootNode) {
     rootNode.x = 0; // Center horizontally
-    rootNode.y = -height * 0.7; // Increased negative value to position even higher
+    rootNode.y = -height * 0.9; // Position much higher (was 0.7)
     rootNode.fx = 0; // Fix position horizontally
-    rootNode.fy = -height * 0.7; // Increased negative value to position even higher
+    rootNode.fy = -height * 0.9; // Fix position vertically (was 0.7)
   }
   
-  // Arrange non-root nodes in a semi-circle below the root node
-  const radius = Math.min(width, height) * 0.25; // Use 25% of the smaller dimension for radius
-  nonRootNodes.forEach((node, i) => {
-    // Use a semi-circle (180 degrees) below the root
-    const angle = (Math.PI * i) / (nonRootNodes.length - 1);
-    node.x = radius * Math.cos(angle); // Position in semi-circle
-    node.y = -height * 0.7 + radius * Math.sin(angle) + radius; // Position below root node
+  // Arrange non-root nodes in a tiered layout instead of a semi-circle
+  // First identify first-level nodes (directly connected to root)
+  const firstLevelIds = new Set();
+  edges.forEach(edge => {
+    if (edge.from === rootSubject) {
+      firstLevelIds.add(edge.to);
+    } else if (edge.to === rootSubject) {
+      firstLevelIds.add(edge.from);
+    }
+  });
+  
+  // Now position nodes in tiers
+  nonRootNodes.forEach(node => {
+    // Randomize x position slightly for each node
+    const xOffset = (Math.random() - 0.5) * width * 0.6;
+    
+    if (firstLevelIds.has(node.id)) {
+      // First tier - below root but in a more spread out arrangement
+      node.x = xOffset;
+      node.y = -height * 0.5; // First tier below root
+    } else {
+      // Second+ tier - further below
+      node.x = xOffset * 1.2; // Wider spread for lower tiers
+      node.y = -height * 0.1 + (Math.random() * height * 0.3); // Variable positions lower down
+    }
   });
   
   // Preprocess edges to ensure all source and target nodes exist
@@ -2118,7 +2136,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
    
   // Start displaying first-level nodes progressively now that nodeElements is defined
   displayNodesProgressively();
-  
+    
   // Add rectangles to nodes
   nodeElements.append('rect')
     .attr('rx', 4)
@@ -2232,18 +2250,18 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Add text labels with wrapping
   labelElements.each(function(d) {
     try {
-      const labelGroup = d3.select(this);
-      const label = d.label || "";
-      
-      // Skip empty labels
-      if (!label.trim()) {
-        labelGroup.append('text')
-          .attr('class', 'link-label')
-          .attr('fill', '#475569')
-          .text("");
-        return;
-      }
-      
+    const labelGroup = d3.select(this);
+    const label = d.label || "";
+    
+    // Skip empty labels
+    if (!label.trim()) {
+      labelGroup.append('text')
+        .attr('class', 'link-label')
+        .attr('fill', '#475569')
+        .text("");
+      return;
+    }
+    
       // For "Son of" relationship, use special styling and don't wrap
       const isSonOfRelation = label.includes("Son of") || label.includes("Child of") || 
                              label.includes("Parent of") || label.includes("Father of") || 
@@ -2260,17 +2278,17 @@ function renderD3Graph(rootSubject, nodes, edges) {
           .text(label);
       } else {
         // Wrap text to max 20 characters per line for other relationships
-        const wrappedText = wrapText(label, 20);
-        
-        // Add each line of text
-        wrappedText.forEach((line, i) => {
-          labelGroup.append('text')
-            .attr('class', 'link-label')
-            .attr('fill', '#475569')
-            .attr('text-anchor', 'middle') // Center text
-            .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
-            .text(line);
-        });
+    const wrappedText = wrapText(label, 20);
+    
+    // Add each line of text
+    wrappedText.forEach((line, i) => {
+      labelGroup.append('text')
+        .attr('class', 'link-label')
+        .attr('fill', '#475569')
+        .attr('text-anchor', 'middle') // Center text
+        .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
+        .text(line);
+    });
       }
       
       if (!d.pathPoints) {
@@ -2480,17 +2498,25 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .force('x', d3.forceX(d => {
       if (d.id === rootSubject) return 0;
       if (firstLevelNodeIds.has(d.id)) {
-        return d.x * 1.7; // Push first level nodes further out horizontally
+        // Spread first level nodes horizontally
+        const index = Array.from(firstLevelNodeIds).indexOf(d.id);
+        const angleStep = Math.PI / Math.max(firstLevelNodeIds.size, 1);
+        const angle = (index * angleStep) - Math.PI/2;
+        return 300 * Math.cos(angle); // Circular arrangement
       }
-      return d.x;
-    }).strength(0.25))
+      return d.x * 0.5; // Weaker horizontal force for other nodes
+    }).strength(0.5))
     .force('y', d3.forceY(d => {
-      if (d.id === rootSubject) return -height * 0.7; // Increased negative value for higher positioning
+      if (d.id === rootSubject) return -height * 0.9; // Keep root very high
       if (firstLevelNodeIds.has(d.id)) {
-        return d.y; // Keep first level at their y positions
+        // Position first level nodes in a semi-circle below root
+        const index = Array.from(firstLevelNodeIds).indexOf(d.id);
+        const angleStep = Math.PI / Math.max(firstLevelNodeIds.size, 1);
+        const angle = (index * angleStep) - Math.PI/2;
+        return -height * 0.5 + 300 * Math.max(0, Math.sin(angle)); // Create arc below root
       }
-      return height * 0.35; // Push other nodes down more
-    }).strength(0.25))
+      return height * 0.2; // Push other nodes down more
+    }).strength(0.5)) // Stronger vertical force
     .force('collision', d3.forceCollide()
       .radius(d => {
         // Even larger collision radius to keep nodes well separated
@@ -2518,9 +2544,9 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .distance(d => {
         // Use different distances for different types of connections
         if (d.from === rootSubject || d.to === rootSubject) {
-          return forceParams.linkDistance * 8; // Reduced from 10
+          return forceParams.linkDistance * 12; // Increased from 8 to create more vertical separation
         }
-        return forceParams.linkDistance * 5; // Reduced from 7
+        return forceParams.linkDistance * 6; // Slightly increased for all other connections
       }))
     .force('charge', d3.forceManyBody()
       .strength(d => {
@@ -2538,26 +2564,32 @@ function renderD3Graph(rootSubject, nodes, edges) {
       // Root node stays at center
       if (d.id === rootSubject) return 0;
       
-      // First level nodes maintain their existing x position but with scaling
+      // First level nodes - spread them horizontally in an arc
       if (firstLevelNodeIds.has(d.id)) {
-        return d.x * 1.2; // Reduced from 1.3
+        const index = Array.from(firstLevelNodeIds).indexOf(d.id);
+        const angleStep = Math.PI / Math.max(firstLevelNodeIds.size, 1);
+        const angle = (index * angleStep) - Math.PI/2;
+        return 350 * Math.cos(angle); // Circular arrangement
       }
       
       // Second level nodes spread wider
-      return d.x * 1.3; // Reduced from 1.4
-    }).strength(d => d.id === rootSubject ? 1 : 0.3)) // Increased from 0.2 for faster positioning
+      return d.x * 1.2;
+    }).strength(d => d.id === rootSubject ? 1 : 0.5)) // Stronger force to maintain structure
     .force('y', d3.forceY(d => {
       // Keep root at top
-      if (d.id === rootSubject) return -height * 0.7; // Increased negative value for higher positioning
+      if (d.id === rootSubject) return -height * 0.9; // Position root very high
       
-      // First level nodes position
+      // First level nodes positioned in arc below root
       if (firstLevelNodeIds.has(d.id)) {
-        return d.y * 0.9; // Adjust as needed
+        const index = Array.from(firstLevelNodeIds).indexOf(d.id);
+        const angleStep = Math.PI / Math.max(firstLevelNodeIds.size, 1);
+        const angle = (index * angleStep) - Math.PI/2;
+        return -height * 0.5 + 300 * Math.max(0, Math.sin(angle)); // Semi-circular arrangement
       }
       
-      // Second level nodes position
-      return d.y * 1.2; // Reduced from 1.3
-    }).strength(d => d.id === rootSubject ? 1 : 0.4)) // Increased from 0.35
+      // Second level nodes positioned at bottom
+      return height * 0.3; // Push other nodes further down
+    }).strength(d => d.id === rootSubject ? 1 : 0.6)) // Stronger vertical force
     .force('collision', d3.forceCollide().radius(d => {
       // Use much larger collision radius
       const nodeWidth = getNodeWidth(d);
@@ -2613,10 +2645,10 @@ function displayNodesProgressively() {
       rootDiv.className = 'opacity-0 transition-opacity duration-300 py-1';
       
       // Add the root node ID as the main text
-      const nodeIdSpan = document.createElement('div');
-      nodeIdSpan.className = 'font-bold';
-      nodeIdSpan.textContent = rootNode.id;
-      rootDiv.appendChild(nodeIdSpan);
+      // const nodeIdSpan = document.createElement('div');
+      // nodeIdSpan.className = 'font-bold';
+      // nodeIdSpan.textContent = rootNode.id;
+      // rootDiv.appendChild(nodeIdSpan);
       
       // Add text indicating this is the root node
       const relationSpan = document.createElement('div');
@@ -2763,9 +2795,25 @@ function ticked() {
     simulation.nodes().forEach(d => {
       if (d.id === rootSubject) {
         d.x = 0;
-        d.y = -height * 0.5; // Increased to position higher (was 0.4)
+        d.y = -height * 0.9; // Position root much higher
         d.fx = 0;
-        d.fy = -height * 0.5; // Increased to position higher (was 0.4)
+        d.fy = -height * 0.9; // Position root much higher
+      }
+      
+      // Keep first level nodes in their semi-circular arrangement
+      if (firstLevelNodeIds.has(d.id)) {
+        // Limit vertical movement - first level nodes shouldn't go above a certain point
+        if (d.y < -height * 0.3) {
+          d.y = Math.max(d.y, -height * 0.3);
+        }
+      }
+      
+      // Enforce hierarchical layout - non-root nodes should never go above the root
+      if (d.id !== rootSubject) {
+        // Keep all non-root nodes below the root node by at least some margin
+        if (d.y < -height * 0.7) {
+          d.y = -height * 0.7;
+        }
       }
     });
     
@@ -2863,10 +2911,10 @@ function ticked() {
         
         // Direct line for debugging
         if (window.debugMode) {
-          const sourceX = sourceNode.x;
-          const sourceY = sourceNode.y;
-          const targetX = targetNode.x;
-          const targetY = targetNode.y;
+        const sourceX = sourceNode.x;
+        const sourceY = sourceNode.y;
+        const targetX = targetNode.x;
+        const targetY = targetNode.y;
           return `M${sourceX},${sourceY} L${targetX},${targetY}`;
         }
         
@@ -2972,7 +3020,7 @@ function ticked() {
             const cp2x = sourcePoint.x + dx * 0.9;
             const cp2y = sourcePoint.y + dy * (1 - randomOffset);
             
-            path = `M${sourcePoint.x},${sourcePoint.y} 
+          path = `M${sourcePoint.x},${sourcePoint.y} 
                     C${cp1x},${cp1y} ${cp2x},${cp2y} ${targetPoint.x},${targetPoint.y}`;
           } else if (Math.abs(sourceLayer - targetLayer) <= 1) {
             // Nodes are on similar layers - use a curved path
@@ -2983,7 +3031,7 @@ function ticked() {
             
             path = `M${sourcePoint.x},${sourcePoint.y} 
                     Q${midX},${midY} ${targetPoint.x},${targetPoint.y}`;
-          } else {
+        } else {
             // Significant horizontal distance - use orthogonal routing with randomized midpoints
             const midX = (sourcePoint.x + targetPoint.x) / 2 + 
                       ((sourceId.length * targetId.length) % 100 - 50);
@@ -2991,7 +3039,7 @@ function ticked() {
             const midY1 = sourcePoint.y + (isSourceHigher ? yDiff * 0.25 : -yDiff * 0.25);
             const midY2 = targetPoint.y + (isSourceHigher ? -yDiff * 0.25 : yDiff * 0.25);
             
-            path = `M${sourcePoint.x},${sourcePoint.y} 
+          path = `M${sourcePoint.x},${sourcePoint.y} 
                     C${sourcePoint.x},${midY1} ${midX},${midY1} ${midX},${(midY1 + midY2) / 2}
                     S${targetPoint.x},${midY2} ${targetPoint.x},${targetPoint.y}`;
           }
@@ -3126,9 +3174,9 @@ function ticked() {
           let labelHeight = 0;
           
           // Calculate total width and height based on all text elements
-          textElements.each(function() {
+        textElements.each(function() {
             try {
-              const bbox = this.getBBox();
+          const bbox = this.getBBox();
               labelWidth = Math.max(labelWidth, bbox.width);
               labelHeight += bbox.height;
             } catch (e) {

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741018182">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741018182">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741018519">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741018519">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -2025,6 +2025,10 @@ function zoomToFitAll() {
     );
 }
 
+// Call the overlap prevention after the simulation has stabilized
+simulation.on('end', preventLabelOverlaps);
+
+// Update the ticked function to occasionally prevent overlaps
 function ticked() {
   // Update node positions
   nodeElements.attr('transform', d => {
@@ -2067,17 +2071,30 @@ function ticked() {
     
     if (!sourcePoint || !targetPoint) return '';
     
-    // Add a slight curve to the path to make overlapping paths more visible
-    const dx = targetPoint.x - sourcePoint.x;
-    const dy = targetPoint.y - sourcePoint.y;
-    const dr = Math.sqrt(dx * dx + dy * dy) * 1.2;
+    // Create orthogonal (right-angled) paths
+    // Determine if the path should go horizontally first or vertically first
+    const dx = Math.abs(targetPoint.x - sourcePoint.x);
+    const dy = Math.abs(targetPoint.y - sourcePoint.y);
     
-    // Use curved paths for better visibility when there are multiple edges
-    return `M${sourcePoint.x},${sourcePoint.y} A${dr},${dr} 0 0,1 ${targetPoint.x},${targetPoint.y}`;
+    // If nodes are more separated horizontally than vertically, go horizontal first
+    if (dx > dy) {
+      const midX = sourcePoint.x + (targetPoint.x - sourcePoint.x) / 2;
+      return `M${sourcePoint.x},${sourcePoint.y} 
+              L${midX},${sourcePoint.y} 
+              L${midX},${targetPoint.y} 
+              L${targetPoint.x},${targetPoint.y}`;
+    } else {
+      // Otherwise go vertical first
+      const midY = sourcePoint.y + (targetPoint.y - sourcePoint.y) / 2;
+      return `M${sourcePoint.x},${sourcePoint.y} 
+              L${sourcePoint.x},${midY} 
+              L${targetPoint.x},${midY} 
+              L${targetPoint.x},${targetPoint.y}`;
+    }
   });
   
-  // Update label positions
-  labelElements.attr('transform', d => {
+  // Update label positions with collision detection
+  labelElements.attr('transform', function(d) {
     const path = linkElements.filter(l => l === d).node();
     if (!path) return '';
     
@@ -2086,6 +2103,11 @@ function ticked() {
     
     // Position label at the midpoint of the path
     const midPoint = path.getPointAtLength(pathLength / 2);
+    
+    // Store the midpoint for collision detection
+    d.labelX = midPoint.x;
+    d.labelY = midPoint.y;
+    
     return `translate(${midPoint.x}, ${midPoint.y})`;
   });
   
@@ -2114,6 +2136,11 @@ function ticked() {
       .attr('width', maxX - minX + padding.x * 2)
       .attr('height', maxY - minY + padding.y * 2);
   });
+  
+  // Occasionally prevent label overlaps during simulation
+  if (Math.random() < 0.1) {
+    preventLabelOverlaps();
+  }
 }
 
 function dragStarted(event, d) {
@@ -2232,6 +2259,90 @@ function lineIntersection(x1, y1, x2, y2, x3, y3, x4, y4) {
   const y = y1 + ua * (y2 - y1);
   
   return { x, y };
+}
+
+// After positioning all labels, adjust positions to prevent overlaps
+function preventLabelOverlaps() {
+  const labels = labelElements.nodes();
+  const labelData = labelElements.data();
+  
+  // Create a quadtree for efficient collision detection
+  const quadtree = d3.quadtree()
+    .x(d => d.labelX)
+    .y(d => d.labelY)
+    .addAll(labelData);
+  
+  // For each label, check for overlaps and adjust position
+  labelElements.each(function(d, i) {
+    const labelGroup = d3.select(this);
+    const labelBg = labelGroup.select('.label-bg').node();
+    if (!labelBg) return;
+    
+    const bbox = labelBg.getBBox();
+    const padding = 10; // Extra space between labels
+    
+    // Define the bounds of this label
+    const x0 = d.labelX + bbox.x - padding;
+    const y0 = d.labelY + bbox.y - padding;
+    const x1 = d.labelX + bbox.x + bbox.width + padding;
+    const y1 = d.labelY + bbox.y + bbox.height + padding;
+    
+    // Find nearby labels that might overlap
+    quadtree.visit((node, x1q, y1q, x2q, y2q) => {
+      if (!node.length) {
+        do {
+          const d2 = node.data;
+          if (d2 && d2 !== d && labelOverlap(d, d2, bbox, padding)) {
+            // Adjust position to avoid overlap
+            adjustLabelPosition(d, d2);
+          }
+        } while (node = node.next);
+      }
+      return x1q > x1 || y1q > y1 || x2q < x0 || y2q < y0;
+    });
+    
+    // Update the transform with the potentially adjusted position
+    labelGroup.attr('transform', `translate(${d.labelX}, ${d.labelY})`);
+  });
+}
+
+// Check if two labels overlap
+function labelOverlap(d1, d2, bbox, padding) {
+  // Find the index of d2 in the data array
+  const d2Index = labelElements.data().indexOf(d2);
+  const labelGroup2 = d3.select(labelElements.nodes()[d2Index]);
+  const labelBg2 = labelGroup2.select('.label-bg').node();
+  if (!labelBg2) return false;
+  
+  const bbox2 = labelBg2.getBBox();
+  
+  // Check for rectangle overlap
+  return !(
+    d1.labelX + bbox.x + bbox.width + padding < d2.labelX + bbox2.x ||
+    d1.labelX + bbox.x > d2.labelX + bbox2.x + bbox2.width + padding ||
+    d1.labelY + bbox.y + bbox.height + padding < d2.labelY + bbox2.y ||
+    d1.labelY + bbox.y > d2.labelY + bbox2.y + bbox2.height + padding
+  );
+}
+
+// Adjust label position to avoid overlap
+function adjustLabelPosition(d1, d2) {
+  // Calculate vector between labels
+  const dx = d2.labelX - d1.labelX;
+  const dy = d2.labelY - d1.labelY;
+  const distance = Math.sqrt(dx * dx + dy * dy);
+  
+  if (distance < 1) {
+    // If labels are at the same position, move in a random direction
+    const angle = Math.random() * Math.PI * 2;
+    d1.labelX += Math.cos(angle) * 30;
+    d1.labelY += Math.sin(angle) * 30;
+  } else {
+    // Move away from the other label
+    const moveDistance = 30; // Distance to move
+    d1.labelX -= (dx / distance) * moveDistance;
+    d1.labelY -= (dy / distance) * moveDistance;
+  }
 }
 </script>
 

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741045845">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741045845">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741046045">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741046045">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -3689,27 +3689,11 @@ function getNodeLayer(nodeId, edgesParam) {
   return 3; // Everything else is layer 3 or beyond
 }
 
-// Add text to labels
-labelElements.append('text')
-  .attr('class', 'link-label')
-  .attr('text-anchor', 'middle')
-  .attr('dominant-baseline', 'middle')
-  .attr('fill', '#374151')
-  .style('pointer-events', 'none')
-  .style('font-size', '12px')
-  .style('font-weight', 'bold')
-  .text(function(d) {
-    // For "Son of" relationships, highlight them with a special format
-    if (d.label && (d.label.includes("Son of") || d.label.includes("Child of") || 
-                    d.label.includes("Parent of") || d.label.includes("Father of") || 
-                    d.label.includes("Mother of"))) {
-      return d.label;
-    }
-    return d.label || '';
-  });
+
 </script>
 </body>
 </html>
+
     </main>
     
 <div class="flex justify-center">

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741033147">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741033147">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741033671">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741033671">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -830,9 +830,25 @@ $(document).ready(function() {
     margin-right: 4px;
     margin-bottom: 4px;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+  .legend-item:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   }
   .legend-item.disabled {
     opacity: 0.5;
+    position: relative;
+  }
+  .legend-item.disabled::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(255, 255, 255, 0.3);
+    border-radius: 4px;
   }
   
   /* Hover effects - using !important to override any inline styles */
@@ -1577,6 +1593,20 @@ async function renderGraphForSubject(subjectName) {
       }
     }
     
+    // Collect unique categories for the legend
+    const uniqueCategories = new Set();
+    for (const edge of edges) {
+      if (edge.category) {
+        uniqueCategories.add(edge.category);
+      }
+    }
+    
+    // Initialize active categories with all categories
+    globalActiveCategories = new Set(uniqueCategories);
+    
+    // Render the legend
+    renderLegend(Array.from(uniqueCategories));
+    
     // Render the graph
     renderD3Graph(subjectName, nodes, edges);
     
@@ -1754,9 +1784,6 @@ function toggleCategory(cat) {
     globalActiveCategories.add(cat);
   }
   
-  // Filter edges based on active categories
-  const activeEdges = globalAllEdges.filter(e => globalActiveCategories.has(e.category));
-  
   // Update edge visibility
   linkElements.attr('visibility', d => 
     globalActiveCategories.has(d.category) ? 'visible' : 'hidden'
@@ -1766,6 +1793,19 @@ function toggleCategory(cat) {
   labelElements.attr('visibility', d => 
     globalActiveCategories.has(d.category) ? 'visible' : 'hidden'
   );
+  
+  // Update edge marker visibility (arrows)
+  linkElements.attr('marker-end', d => 
+    globalActiveCategories.has(d.category) 
+      ? `url(#arrow-${d.category || 'UNKNOWN'})` 
+      : 'none'
+  );
+  
+  // Update legend items visual state
+  $('.legend-item').each(function() {
+    const category = $(this).data('cat');
+    $(this).toggleClass('disabled', !globalActiveCategories.has(category));
+  });
 }
 
 
@@ -1893,7 +1933,22 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Add arrow markers for links
   const defs = g.append('defs');
   
-  // Regular arrow marker
+  // Create marker definitions for each category
+  Object.entries(categoryColors).forEach(([category, color]) => {
+    defs.append('marker')
+      .attr('id', `arrow-${category}`)
+      .attr('viewBox', '0 -5 10 10')
+      .attr('refX', 20)
+      .attr('refY', 0)
+      .attr('markerWidth', 8)
+      .attr('markerHeight', 8)
+      .attr('orient', 'auto')
+      .append('path')
+      .attr('fill', color)
+      .attr('d', 'M0,-5L10,0L0,5');
+  });
+  
+  // Regular arrow marker (fallback)
   defs.append('marker')
     .attr('id', 'arrow')
     .attr('viewBox', '0 -5 10 10')
@@ -1987,11 +2042,15 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .data(validEdges)
     .join('path')
     .attr('class', 'link')
-    .attr('stroke', d => d.color)
+    .attr('stroke', d => {
+      // Get the color from the category using the global categoryColors
+      return categoryColors[d.category] || categoryColors["UNKNOWN"];
+    })
     .attr('stroke-width', 2)
-    .attr('marker-end', 'url(#arrow)')
+    .attr('marker-end', d => `url(#arrow-${d.category || 'UNKNOWN'})`)
     .attr('data-source', d => d.from)
     .attr('data-target', d => d.to)
+    .attr('data-category', d => d.category)
     .style('cursor', 'pointer')
     .on('mouseover', function(event, d) {
       console.log('Link path hover:', d);
@@ -2205,7 +2264,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     linkElements
       .style('stroke', null)
       .style('stroke-width', null)
-      .attr('stroke', d => d.color)
+      .attr('stroke', d => categoryColors[d.category] || categoryColors["UNKNOWN"])
       .attr('stroke-width', 2);
     
     // Reset label styles

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741035866">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741035866">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741036375">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741036375">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -1051,14 +1051,14 @@ let globalActiveCategories = new Set(); // which categories are currently on dis
 
 // Force simulation parameters
 const forceParams = {
-  linkDistance: 600,     // Increased from 400
-  charge: -5000,         // Increased from -3000
-  collisionRadius: 300,  // Increased from 200
+  linkDistance: 1200,     // Doubled from 600
+  charge: -10000,         // Doubled from -5000
+  collisionRadius: 500,   // Increased from 300
   bounds: {
-    left: 150,
-    right: 150,
-    top: 150,
-    bottom: 150
+    left: 300,
+    right: 300,
+    top: 300,
+    bottom: 300
   }
 };
 
@@ -1462,7 +1462,7 @@ async function renderGraphForSubject(subjectName) {
     }
     // Add a title for the summary
     $('#rootSummary').html(`
-      <h3 class="font-bold mb-2 text-navy">${escapeHtml(subjectName)}</h3>
+      <h3 class="font-bold mt-0 mb-2 text-navy">${escapeHtml(subjectName)}</h3>
       ${rootSummaryHtml.join('')}
     `);
     
@@ -1866,7 +1866,7 @@ function initializeD3Graph() {
   
   // Set the SVG viewBox to cover the entire container
   d3.select('#graph')
-    .attr('viewBox', `${-width/2} ${-height/2} ${width} ${height}`)
+    .attr('viewBox', `${-width/1.5} ${-height/1.5} ${width*1.5} ${height*1.5}`)
     .attr('preserveAspectRatio', 'xMidYMid meet');
   
   // Initialize zoom behavior
@@ -1892,7 +1892,7 @@ function resetZoom() {
   // Center the graph with an appropriate scale
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(0, 0).scale(0.8)
+    d3.zoomIdentity.translate(0, 0).scale(0.5) // More zoomed out to see the entire graph
   );
 }
 
@@ -1925,7 +1925,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Reset zoom and pan with centered graph
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(0, 0).scale(0.8) // Center at origin
+    d3.zoomIdentity.translate(0, 0).scale(0.5) // More zoomed out to see the entire graph
   );
   
   // Create the graph content group with initial transform
@@ -2284,44 +2284,23 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .force('link', d3.forceLink()
       .links(validEdges)
       .id(d => d.id)
-      .distance(d => {
-        try {
-          // Get source and target nodes
-          const sourceNode = d.source;
-          const targetNode = d.target;
-          
-          if (!sourceNode || !targetNode) {
-            console.warn("Missing node in link distance calculation");
-            return forceParams.linkDistance * 1.5; // Moderately increased distance
-          }
-          
-          const sourceSize = Math.sqrt(getNodeWidth(sourceNode) * getNodeHeight(sourceNode));
-          const targetSize = Math.sqrt(getNodeWidth(targetNode) * getNodeHeight(targetNode));
-          
-          // Base distance on node sizes plus padding - increased for better spacing
-          return (sourceSize + targetSize) / 2 + forceParams.linkDistance;
-        } catch (error) {
-          console.error("Error in link distance calculation:", error, d);
-          return forceParams.linkDistance * 1.5; // Moderately increased default distance
-        }
-      })
-    )
+      .distance(forceParams.linkDistance * 2)) // Double the link distance
     .force('charge', d3.forceManyBody()
       .strength(d => {
         // Stronger repulsion for structured layout
         const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
-        return forceParams.charge * (nodeSize / 200) * 1.5; // Moderately increased repulsion
+        return forceParams.charge * (nodeSize / 200) * 2.5; // Significantly increased repulsion
       })
-      .distanceMin(300) // Further increased minimum distance
-      .distanceMax(3000)) // Further increased maximum distance
+      .distanceMin(400) // Increased minimum distance
+      .distanceMax(5000)) // Increased maximum distance
     .force('x', d3.forceX(0).strength(0.2)) // Center nodes horizontally at origin
     .force('y', d3.forceY(0).strength(0.2)) // Center nodes vertically at origin
     .force('collision', d3.forceCollide().radius(d => {
       // Make collision radius based on node size plus padding
       const nodeWidth = getNodeWidth(d);
       const nodeHeight = getNodeHeight(d);
-      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 100; // Increased padding significantly
-    }).strength(0.8))
+      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 200; // Significantly increased padding
+    }).strength(1))
     .alpha(0.8) // Higher alpha for more movement
     .alphaDecay(0.01) // Slower decay for more time to find optimal positions
     .velocityDecay(0.4)
@@ -2349,7 +2328,7 @@ function centerGraph() {
     // Update the zoom transform to center the graph
     d3.select('#graph').call(
       zoom.transform,
-      d3.zoomIdentity.translate(translateX, translateY).scale(0.8)
+      d3.zoomIdentity.translate(translateX, translateY).scale(0.5)
     );
     
     console.log('Graph centered based on actual bounds:', { 
@@ -2437,13 +2416,13 @@ function ticked() {
         // Create path with more segments to avoid running behind nodes
         let path = '';
         
-        // Add a small offset to ensure arrows don't touch nodes
-        const arrowOffset = 10;
+        // Remove the offset to ensure lines connect directly to nodes without gaps
+        const arrowOffset = 0;
         
-        // Adjust target point to account for arrow
+        // Adjust target point to account for arrow - no offset to avoid gaps
         const targetPointWithOffset = {
-          x: targetPoint.x + (sourcePoint.x > targetPoint.x ? arrowOffset : -arrowOffset),
-          y: targetPoint.y + (sourcePoint.y > targetPoint.y ? arrowOffset : -arrowOffset)
+          x: targetPoint.x,
+          y: targetPoint.y
         };
         
         if (isHorizontal) {
@@ -2516,15 +2495,15 @@ function ticked() {
                 const midX = (source.x + target.x) / 2;
                 midY = source.y + (target.y - source.y) / 2;
                 
-                // Offset the label to avoid overlapping with the path
-                midY += (source.y > target.y) ? -20 : 20;
+                // Increase offset to avoid overlap
+                midY += (source.y > target.y) ? -40 : 40;
               } else {
                 // For vertical paths, position label to the left or right of the middle segment
                 midX = source.x + (target.x - source.x) / 2;
                 const midY = (source.y + target.y) / 2;
                 
-                // Offset the label to avoid overlapping with the path
-                midX += (source.x > target.x) ? -20 : 20;
+                // Increase offset to avoid overlap
+                midX += (source.x > target.x) ? -40 : 40;
               }
             }
           } else {

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741027815">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741027815">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741028865">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741028865">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -2027,9 +2027,13 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Add text to nodes
   nodeElements.each(function(d) {
     const node = d3.select(this);
-    const bulletInfo = d.bulletInfo;
-    const padding = 10;
+    const bulletInfo = d.bulletInfo || {};
+    const padding = 12;
     let y = padding;
+    
+    // Calculate node width for text wrapping
+    const nodeWidth = getNodeWidth(d);
+    const maxCharsPerLine = Math.floor((nodeWidth - padding * 2) / 6.5); // Adjusted chars per line
     
     // Add subject name
     node.append('text')
@@ -2042,7 +2046,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     
     // Add bullet point 1 if available
     if (bulletInfo && bulletInfo.bullet_point1) {
-      const wrappedText = wrapText(bulletInfo.bullet_point1, 30);
+      const wrappedText = wrapText(bulletInfo.bullet_point1, maxCharsPerLine);
       wrappedText.forEach(line => {
         node.append('text')
           .attr('x', padding)
@@ -2056,7 +2060,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     // Add bullet point 2 if available
     if (bulletInfo && bulletInfo.bullet_point2) {
       y += 5; // Add a little extra space
-      const wrappedText = wrapText(bulletInfo.bullet_point2, 30);
+      const wrappedText = wrapText(bulletInfo.bullet_point2, maxCharsPerLine);
       wrappedText.forEach(line => {
         node.append('text')
           .attr('x', padding)
@@ -2673,23 +2677,29 @@ function getNodeWidth(node) {
     const bullet1 = bulletInfo.bullet_point1 || '';
     const bullet2 = bulletInfo.bullet_point2 || '';
     
-    // Find the longest line after wrapping
-    const wrappedBullet1 = wrapText(bullet1, 30);
-    const wrappedBullet2 = wrapText(bullet2, 30);
+    // If there are no bullet points, use a smaller width
+    if (bullet1.length === 0 && bullet2.length === 0) {
+      node._width = Math.max(textLength * 8 + 40, 120);
+      return node._width;
+    }
     
-    let maxLineLength = textLength;
-    wrappedBullet1.forEach(line => {
-      maxLineLength = Math.max(maxLineLength, line.length);
-    });
-    wrappedBullet2.forEach(line => {
-      maxLineLength = Math.max(maxLineLength, line.length);
-    });
+    // For nodes with descriptions, calculate width based on content
+    // Find the longest line in the bullets
+    const longestBullet = bullet1.length > bullet2.length ? bullet1 : bullet2;
     
-    // Calculate width based on the longest text
-    node._width = Math.max(
-      Math.min(maxLineLength * 8, 350),
-      150
+    // Estimate how many characters we can fit per line
+    // Use a smaller character width to fit more text per line
+    const charWidth = 6.5; // Pixels per character (reduced to fit more text)
+    
+    // Calculate a width that will fit approximately 40-50 chars per line
+    // This ensures text fills the box better
+    const targetCharsPerLine = 45;
+    const contentBasedWidth = Math.min(
+      Math.max(longestBullet.length, textLength * 1.5) * charWidth + 40,
+      targetCharsPerLine * charWidth + 40
     );
+    
+    node._width = Math.max(contentBasedWidth, 220);
   }
   return node._width;
 }
@@ -2703,19 +2713,33 @@ function getNodeHeight(node) {
     const bullet1 = bulletInfo.bullet_point1 || '';
     const bullet2 = bulletInfo.bullet_point2 || '';
     
+    // Use consistent padding (12px) for top, sides, and bottom
+    const padding = 12;
+    
+    // If there are no bullet points, use a smaller height but maintain padding
+    if (bullet1.length === 0 && bullet2.length === 0) {
+      node._height = padding + 18 + padding; // Top padding + title height + bottom padding
+      return node._height;
+    }
+    
+    // Get node width to calculate how many lines we'll need
+    const nodeWidth = getNodeWidth(node);
+    const charsPerLine = Math.floor((nodeWidth - padding * 2) / 6.5); // Characters per line
+    
     // Count lines after wrapping
-    const wrappedBullet1 = wrapText(bullet1, 30);
-    const wrappedBullet2 = wrapText(bullet2, 30);
+    const wrappedBullet1 = wrapText(bullet1, charsPerLine);
+    const wrappedBullet2 = wrapText(bullet2, charsPerLine);
     
     const bulletLines1 = wrappedBullet1.length;
     const bulletLines2 = wrappedBullet2.length;
     
     // Calculate height based on number of lines
-    node._height = 30 + (bulletLines1 + bulletLines2) * 18;
+    // Top padding + title height + bullet points + bottom padding
+    node._height = padding + 18 + (bulletLines1 + bulletLines2) * 18 + padding;
     
-    // Add extra padding if there are two bullet points
+    // Add small padding between bullet points if both exist
     if (bulletLines1 > 0 && bulletLines2 > 0) {
-      node._height += 10;
+      node._height += 5;
     }
     
     // Ensure minimum height
@@ -2726,13 +2750,30 @@ function getNodeHeight(node) {
 
 // Helper function to wrap text to a specified width
 function wrapText(text, maxChars) {
-  if (!text) return [''];
+  if (!text) return [];
   
   const words = text.split(' ');
   const lines = [];
   let currentLine = '';
   
   words.forEach(word => {
+    // If the word itself is longer than maxChars, we need to break it
+    if (word.length > maxChars) {
+      // First add any current line content
+      if (currentLine) {
+        lines.push(currentLine);
+        currentLine = '';
+      }
+      
+      // Then break the long word
+      let i = 0;
+      while (i < word.length) {
+        lines.push(word.substr(i, maxChars));
+        i += maxChars;
+      }
+      return;
+    }
+    
     const testLine = currentLine ? `${currentLine} ${word}` : word;
     if (testLine.length <= maxChars) {
       currentLine = testLine;

--- a/docs/relations/index.html
+++ b/docs/relations/index.html
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741018519">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741018519">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741019912">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741019912">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -1751,6 +1751,29 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Create the graph content group
   const g = d3.select('#graph-content');
   
+  // Separate root node from other nodes
+  const rootNode = nodes.find(n => n.id === rootSubject);
+  const nonRootNodes = nodes.filter(n => n.id !== rootSubject);
+  
+  // Pre-position nodes in a structured layout
+  // Root node at center-top, other nodes in a row below
+  if (rootNode) {
+    rootNode.x = width / 2;
+    rootNode.y = height * 0.2; // Position root node at top
+    rootNode.fx = rootNode.x; // Fix position
+    rootNode.fy = rootNode.y;
+  }
+  
+  // Arrange non-root nodes in a row
+  const rowWidth = width * 0.8; // Use 80% of available width
+  const nodeSpacing = rowWidth / (nonRootNodes.length + 1);
+  
+  nonRootNodes.forEach((node, i) => {
+    node.x = (width * 0.1) + nodeSpacing * (i + 1); // Distribute evenly with margins
+    node.y = height * 0.7; // Position in a row below root
+    // Don't fix these positions completely, but use them as starting points
+  });
+  
   // Create links
   linkElements = g.append('g')
     .attr('class', 'links')
@@ -1843,12 +1866,12 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .style('cursor', 'pointer')
     .on('mouseover', function(event, d) {
       d3.select(this).attr('fill', d.color);
-      d3.select(this.parentNode).select('.link-label').attr('fill', 'white');
+      d3.select(this.parentNode).selectAll('.link-label').attr('fill', 'white');
       linkElements.filter(l => l === d).attr('stroke-width', 4);
     })
     .on('mouseout', function() {
       d3.select(this).attr('fill', '#F3F4F6');
-      d3.select(this.parentNode).select('.link-label').attr('fill', '#475569');
+      d3.select(this.parentNode).selectAll('.link-label').attr('fill', '#475569');
       linkElements.attr('stroke-width', 2);
     });
   
@@ -1905,7 +1928,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
       if (label.from === d.id || label.to === d.id) {
         d3.select(this).select('.label-bg')
           .attr('fill', label.color);
-        d3.select(this).select('.link-label')
+        d3.select(this).selectAll('.link-label')
           .attr('fill', 'white');
       }
     });
@@ -1924,11 +1947,11 @@ function renderD3Graph(rootSubject, nodes, edges) {
     // Reset label styles
     labelElements.select('.label-bg')
       .attr('fill', '#F3F4F6');
-    labelElements.select('.link-label')
+    labelElements.selectAll('.link-label')
       .attr('fill', '#475569');
   });
   
-  // Start the simulation
+  // Start the simulation with modified forces for structured layout
   simulation = d3.forceSimulation(nodes)
     .force('link', d3.forceLink(edges)
       .id(d => d.id)
@@ -1946,25 +1969,35 @@ function renderD3Graph(rootSubject, nodes, edges) {
       }))
     .force('charge', d3.forceManyBody()
       .strength(d => {
-        // Adjust repulsion based on node size
+        // Stronger repulsion for structured layout
         const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
-        return forceParams.charge * (nodeSize / 200);
+        return forceParams.charge * (nodeSize / 200) * 1.5;
       })
-      .distanceMin(150)
+      .distanceMin(200)
       .distanceMax(2000))
-    .force('center', d3.forceCenter(width / 2, height / 2))
-    .force('x', d3.forceX(width / 2).strength(0.05))
-    .force('y', d3.forceY(height / 2).strength(0.05))
+    .force('x', d3.forceX(d => {
+      // Keep root node centered, let others spread horizontally
+      if (d.id === rootSubject) return width / 2;
+      return d.x; // Use pre-positioned x value
+    }).strength(d => d.id === rootSubject ? 1 : 0.2))
+    .force('y', d3.forceY(d => {
+      // Keep root node at top, others in row below
+      if (d.id === rootSubject) return height * 0.2;
+      return height * 0.7;
+    }).strength(0.3))
     .force('collision', d3.forceCollide().radius(d => {
       // Make collision radius based on node size plus padding
       const nodeWidth = getNodeWidth(d);
       const nodeHeight = getNodeHeight(d);
-      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 50;
+      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 70; // Increased padding
     }).strength(1))
-    .alpha(0.6)
-    .alphaDecay(0.01) // Slower decay for more time to find optimal positions
-    .velocityDecay(0.4) // Lower value to allow nodes to move more freely
+    .alpha(0.8) // Higher alpha for more movement
+    .alphaDecay(0.008) // Slower decay for more time to find optimal positions
+    .velocityDecay(0.4)
     .on('tick', ticked);
+  
+  // Force an initial tick to position elements correctly
+  ticked();
   
   // Enable download button
   $('#downloadBtn').show();
@@ -1972,7 +2005,25 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Auto-zoom to fit all nodes after simulation stabilizes
   setTimeout(() => {
     zoomToFitAll();
-  }, 2000);
+    
+    // Run label overlap prevention multiple times during and after stabilization
+    preventLabelOverlaps();
+    
+    // Set up interval to repeatedly check for and fix label overlaps during simulation
+    const labelInterval = setInterval(() => {
+      preventLabelOverlaps();
+      
+      // Stop checking once simulation has cooled down
+      if (simulation.alpha() < 0.05) {
+        clearInterval(labelInterval);
+        // Final adjustment after simulation ends
+        setTimeout(() => {
+          preventLabelOverlaps();
+          ticked(); // Force one more update
+        }, 500);
+      }
+    }, 200);
+  }, 1000);
 }
 
 // Function to zoom to fit all nodes
@@ -2025,10 +2076,7 @@ function zoomToFitAll() {
     );
 }
 
-// Call the overlap prevention after the simulation has stabilized
-simulation.on('end', preventLabelOverlaps);
-
-// Update the ticked function to occasionally prevent overlaps
+// Update the ticked function to properly position labels along their paths
 function ticked() {
   // Update node positions
   nodeElements.attr('transform', d => {
@@ -2038,7 +2086,7 @@ function ticked() {
     return `translate(${d.x - getNodeWidth(d) / 2}, ${d.y - getNodeHeight(d) / 2})`;
   });
   
-  // Update link paths
+  // Update link paths with improved orthogonal routing
   linkElements.attr('d', d => {
     const sourceNode = nodeElements.filter(n => n.id === d.from).datum();
     const targetNode = nodeElements.filter(n => n.id === d.to).datum();
@@ -2071,44 +2119,77 @@ function ticked() {
     
     if (!sourcePoint || !targetPoint) return '';
     
-    // Create orthogonal (right-angled) paths
-    // Determine if the path should go horizontally first or vertically first
-    const dx = Math.abs(targetPoint.x - sourcePoint.x);
-    const dy = Math.abs(targetPoint.y - sourcePoint.y);
+    // Create orthogonal (right-angled) paths with better routing
+    // For structured layout, we want to route from top to bottom
+    // with horizontal segments as needed
     
-    // If nodes are more separated horizontally than vertically, go horizontal first
-    if (dx > dy) {
-      const midX = sourcePoint.x + (targetPoint.x - sourcePoint.x) / 2;
-      return `M${sourcePoint.x},${sourcePoint.y} 
-              L${midX},${sourcePoint.y} 
-              L${midX},${targetPoint.y} 
-              L${targetPoint.x},${targetPoint.y}`;
-    } else {
-      // Otherwise go vertical first
-      const midY = sourcePoint.y + (targetPoint.y - sourcePoint.y) / 2;
-      return `M${sourcePoint.x},${sourcePoint.y} 
-              L${sourcePoint.x},${midY} 
-              L${targetPoint.x},${midY} 
-              L${targetPoint.x},${targetPoint.y}`;
-    }
+    // Calculate midpoint Y position - place it closer to the higher node
+    const sourceIsHigher = sourcePoint.y < targetPoint.y;
+    const higherY = Math.min(sourcePoint.y, targetPoint.y);
+    const lowerY = Math.max(sourcePoint.y, targetPoint.y);
+    const yDiff = lowerY - higherY;
+    
+    // Place the horizontal segment at 1/3 of the distance from the higher node
+    const midY = higherY + yDiff * (sourceIsHigher ? 0.33 : 0.67);
+    
+    // Create the path
+    return `M${sourcePoint.x},${sourcePoint.y} 
+            L${sourcePoint.x},${midY} 
+            L${targetPoint.x},${midY} 
+            L${targetPoint.x},${targetPoint.y}`;
   });
   
-  // Update label positions with collision detection
+  // Update label positions with improved placement
   labelElements.attr('transform', function(d) {
-    const path = linkElements.filter(l => l === d).node();
+    const path = linkElements.filter(l => l.source === d.source && l.target === d.target).node();
     if (!path) return '';
     
     const pathLength = path.getTotalLength();
     if (isNaN(pathLength) || pathLength === 0) return '';
     
-    // Position label at the midpoint of the path
-    const midPoint = path.getPointAtLength(pathLength / 2);
+    // For structured layout, we want to position labels further from the source node
+    // to prevent overlapping - use positions between 60% and 80% along the path
+    // This places labels closer to the target node and away from the crowded center
     
-    // Store the midpoint for collision detection
-    d.labelX = midPoint.x;
-    d.labelY = midPoint.y;
+    // Calculate position based on source node's position in the layout
+    const sourceNode = nodeElements.filter(n => n.id === d.from).datum();
+    const targetNode = nodeElements.filter(n => n.id === d.to).datum();
     
-    return `translate(${midPoint.x}, ${midPoint.y})`;
+    if (!sourceNode || !targetNode) {
+      // Fallback to midpoint if nodes not found
+      const midPoint = path.getPointAtLength(pathLength / 2);
+      d.labelX = midPoint.x;
+      d.labelY = midPoint.y;
+      return `translate(${midPoint.x}, ${midPoint.y})`;
+    }
+    
+    // Determine if this is a connection from root to child or between other nodes
+    const rootNode = d3.select('.node.root').datum();
+    const isRootToChild = sourceNode.id === rootNode.id;
+    
+    // Position labels at different points along the path based on connection type
+    let positionRatio;
+    
+    if (isRootToChild) {
+      // For root-to-child connections, position labels at 70% along the path
+      // This places them closer to the child nodes and away from the crowded center
+      positionRatio = 0.7;
+    } else {
+      // For other connections, use a position that's 60% along the path
+      positionRatio = 0.6;
+    }
+    
+    // Get the point at the calculated position
+    const labelPoint = path.getPointAtLength(pathLength * positionRatio);
+    
+    // Store the position for collision detection
+    d.labelX = labelPoint.x;
+    d.labelY = labelPoint.y;
+    d.pathLength = pathLength;
+    d.path = path;
+    d.positionRatio = positionRatio;
+    
+    return `translate(${labelPoint.x}, ${labelPoint.y})`;
   });
   
   // Update label background sizes
@@ -2136,11 +2217,6 @@ function ticked() {
       .attr('width', maxX - minX + padding.x * 2)
       .attr('height', maxY - minY + padding.y * 2);
   });
-  
-  // Occasionally prevent label overlaps during simulation
-  if (Math.random() < 0.1) {
-    preventLabelOverlaps();
-  }
 }
 
 function dragStarted(event, d) {
@@ -2261,88 +2337,129 @@ function lineIntersection(x1, y1, x2, y2, x3, y3, x4, y4) {
   return { x, y };
 }
 
-// After positioning all labels, adjust positions to prevent overlaps
+// Improved label overlap prevention
 function preventLabelOverlaps() {
-  const labels = labelElements.nodes();
   const labelData = labelElements.data();
+  if (!labelData.length) return;
   
-  // Create a quadtree for efficient collision detection
-  const quadtree = d3.quadtree()
-    .x(d => d.labelX)
-    .y(d => d.labelY)
-    .addAll(labelData);
+  // First pass: group labels by their vertical position into rows
+  const verticalThreshold = 30;
+  const rows = [];
+  let currentRow = [];
   
-  // For each label, check for overlaps and adjust position
-  labelElements.each(function(d, i) {
-    const labelGroup = d3.select(this);
-    const labelBg = labelGroup.select('.label-bg').node();
-    if (!labelBg) return;
-    
-    const bbox = labelBg.getBBox();
-    const padding = 10; // Extra space between labels
-    
-    // Define the bounds of this label
-    const x0 = d.labelX + bbox.x - padding;
-    const y0 = d.labelY + bbox.y - padding;
-    const x1 = d.labelX + bbox.x + bbox.width + padding;
-    const y1 = d.labelY + bbox.y + bbox.height + padding;
-    
-    // Find nearby labels that might overlap
-    quadtree.visit((node, x1q, y1q, x2q, y2q) => {
-      if (!node.length) {
-        do {
-          const d2 = node.data;
-          if (d2 && d2 !== d && labelOverlap(d, d2, bbox, padding)) {
-            // Adjust position to avoid overlap
-            adjustLabelPosition(d, d2);
-          }
-        } while (node = node.next);
+  // Sort labels by y-position first
+  const sortedLabels = [...labelData].sort((a, b) => a.labelY - b.labelY);
+  
+  sortedLabels.forEach(label => {
+    if (!currentRow.length) {
+      currentRow.push(label);
+    } else {
+      const lastLabel = currentRow[currentRow.length - 1];
+      if (Math.abs(label.labelY - lastLabel.labelY) < verticalThreshold) {
+        currentRow.push(label);
+      } else {
+        rows.push([...currentRow]);
+        currentRow = [label];
       }
-      return x1q > x1 || y1q > y1 || x2q < x0 || y2q < y0;
+    }
+  });
+  
+  // Add the last row
+  if (currentRow.length) rows.push(currentRow);
+  
+  // Second pass: for each row, resolve horizontal overlaps
+  rows.forEach(row => {
+    if (row.length <= 1) return; // No overlaps with single label
+    
+    // Sort by x-position
+    row.sort((a, b) => a.labelX - b.labelX);
+    
+    // Get label widths and calculate minimum required space
+    const labelWidths = row.map(label => {
+      const labelIndex = labelData.indexOf(label);
+      const labelElement = d3.select(labelElements.nodes()[labelIndex]);
+      const labelBg = labelElement.select('.label-bg').node();
+      return labelBg ? labelBg.getBBox().width : 0;
     });
     
-    // Update the transform with the potentially adjusted position
-    labelGroup.attr('transform', `translate(${d.labelX}, ${d.labelY})`);
+    // Calculate total width and required spacing
+    const minSpacing = 30; // Increased minimum spacing between labels
+    
+    // Check for overlaps and adjust positions
+    for (let i = 0; i < row.length - 1; i++) {
+      const currentLabel = row[i];
+      const nextLabel = row[i + 1];
+      
+      const currentWidth = labelWidths[i];
+      const nextWidth = labelWidths[i + 1];
+      
+      const currentRight = currentLabel.labelX + (currentWidth / 2);
+      const nextLeft = nextLabel.labelX - (nextWidth / 2);
+      
+      // If labels overlap or are too close
+      if (nextLeft - currentRight < minSpacing) {
+        // Calculate how much we need to move
+        const moveDistance = (minSpacing - (nextLeft - currentRight)) / 2;
+        
+        // Move current label left and next label right
+        if (currentLabel.path && nextLabel.path) {
+          // Adjust position ratios to move labels apart
+          currentLabel.positionRatio = Math.max(0.4, currentLabel.positionRatio - 0.1);
+          nextLabel.positionRatio = Math.min(0.9, nextLabel.positionRatio + 0.1);
+          
+          // Update positions based on new ratios
+          const currentPoint = currentLabel.path.getPointAtLength(currentLabel.pathLength * currentLabel.positionRatio);
+          const nextPoint = nextLabel.path.getPointAtLength(nextLabel.pathLength * nextLabel.positionRatio);
+          
+          currentLabel.labelX = currentPoint.x;
+          currentLabel.labelY = currentPoint.y;
+          nextLabel.labelX = nextPoint.x;
+          nextLabel.labelY = nextPoint.y;
+          
+          // Update the DOM
+          const currentIndex = labelData.indexOf(currentLabel);
+          const nextIndex = labelData.indexOf(nextLabel);
+          
+          d3.select(labelElements.nodes()[currentIndex])
+            .attr('transform', `translate(${currentLabel.labelX}, ${currentLabel.labelY})`);
+          
+          d3.select(labelElements.nodes()[nextIndex])
+            .attr('transform', `translate(${nextLabel.labelX}, ${nextLabel.labelY})`);
+        } else {
+          // Fallback if path information is not available
+          currentLabel.labelX -= moveDistance;
+          nextLabel.labelX += moveDistance;
+          
+          const currentIndex = labelData.indexOf(currentLabel);
+          const nextIndex = labelData.indexOf(nextLabel);
+          
+          d3.select(labelElements.nodes()[currentIndex])
+            .attr('transform', `translate(${currentLabel.labelX}, ${currentLabel.labelY})`);
+          
+          d3.select(labelElements.nodes()[nextIndex])
+            .attr('transform', `translate(${nextLabel.labelX}, ${nextLabel.labelY})`);
+        }
+      }
+    }
   });
-}
-
-// Check if two labels overlap
-function labelOverlap(d1, d2, bbox, padding) {
-  // Find the index of d2 in the data array
-  const d2Index = labelElements.data().indexOf(d2);
-  const labelGroup2 = d3.select(labelElements.nodes()[d2Index]);
-  const labelBg2 = labelGroup2.select('.label-bg').node();
-  if (!labelBg2) return false;
   
-  const bbox2 = labelBg2.getBBox();
-  
-  // Check for rectangle overlap
-  return !(
-    d1.labelX + bbox.x + bbox.width + padding < d2.labelX + bbox2.x ||
-    d1.labelX + bbox.x > d2.labelX + bbox2.x + bbox2.width + padding ||
-    d1.labelY + bbox.y + bbox.height + padding < d2.labelY + bbox2.y ||
-    d1.labelY + bbox.y > d2.labelY + bbox2.y + bbox2.height + padding
-  );
-}
-
-// Adjust label position to avoid overlap
-function adjustLabelPosition(d1, d2) {
-  // Calculate vector between labels
-  const dx = d2.labelX - d1.labelX;
-  const dy = d2.labelY - d1.labelY;
-  const distance = Math.sqrt(dx * dx + dy * dy);
-  
-  if (distance < 1) {
-    // If labels are at the same position, move in a random direction
-    const angle = Math.random() * Math.PI * 2;
-    d1.labelX += Math.cos(angle) * 30;
-    d1.labelY += Math.sin(angle) * 30;
-  } else {
-    // Move away from the other label
-    const moveDistance = 30; // Distance to move
-    d1.labelX -= (dx / distance) * moveDistance;
-    d1.labelY -= (dy / distance) * moveDistance;
-  }
+  // Third pass: stagger labels vertically within rows to further reduce overlaps
+  rows.forEach(row => {
+    if (row.length <= 2) return; // No need to stagger if only 1-2 labels
+    
+    row.forEach((label, i) => {
+      // Apply a slight vertical offset based on position in row
+      // Odd indices go up, even indices go down
+      const verticalOffset = (i % 2 === 0) ? -15 : 15;
+      
+      label.labelY += verticalOffset;
+      
+      // Update the DOM
+      const labelIndex = labelData.indexOf(label);
+      d3.select(labelElements.nodes()[labelIndex])
+        .attr('transform', `translate(${label.labelX}, ${label.labelY})`);
+    });
+  });
 }
 </script>
 

--- a/docs/relations/index.html.backup
+++ b/docs/relations/index.html.backup
@@ -6,8 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="/assets/css/styles.css?v=1741035866">
-<link rel="stylesheet" href="/assets/css/map-style.css?v=1741035866">
+  <link rel="stylesheet" href="/assets/css/styles.css?v=1741035239">
+<link rel="stylesheet" href="/assets/css/map-style.css?v=1741035239">
 <script src="/assets/js/jquery.min.js"></script>
 <script src="/assets/js/functions.js"></script>
 
@@ -43,8 +43,8 @@ $(document).ready(function() {
 <meta property="og:locale" content="en_US" />
 <meta name="description" content="Tracking where the money goes" />
 <meta property="og:description" content="Tracking where the money goes" />
-<link rel="canonical" href="http://localhost:4000/relations/" />
-<meta property="og:url" content="http://localhost:4000/relations/" />
+<link rel="canonical" href="http://localhost:4000/relations/index.html.backup" />
+<meta property="og:url" content="http://localhost:4000/relations/index.html.backup" />
 <meta property="og:site_name" content="DataRepublican" />
 <meta property="og:image" content="http://localhost:4000/assets/images/og-3-1.png" />
 <meta property="og:type" content="website" />
@@ -52,7 +52,7 @@ $(document).ready(function() {
 <meta property="twitter:image" content="http://localhost:4000/assets/images/og-3-1.png" />
 <meta property="twitter:title" content="People Relations (BETA)" />
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"WebPage","description":"Tracking where the money goes","headline":"People Relations (BETA)","image":"http://localhost:4000/assets/images/og-3-1.png","url":"http://localhost:4000/relations/"}</script>
+{"@context":"https://schema.org","@type":"WebPage","description":"Tracking where the money goes","headline":"People Relations (BETA)","image":"http://localhost:4000/assets/images/og-3-1.png","url":"http://localhost:4000/relations/index.html.backup"}</script>
 <!-- End Jekyll SEO tag -->
 
 </head>
@@ -137,7 +137,7 @@ $(document).ready(function() {
   href="/expose" 
   class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-transparent hover:border-white/75 hover:bg-white/10 flex-col text-white select-none "
   
-  title="/relations | /expose"
+  title="/relationsindex | /expose"
 >
   
   <strong class="md:text-sm">
@@ -153,7 +153,7 @@ $(document).ready(function() {
   href="/nonprofit" 
   class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-transparent hover:border-white/75 hover:bg-white/10 flex-col text-white select-none "
   
-  title="/relations | /nonprofit"
+  title="/relationsindex | /nonprofit"
 >
   
   <strong class="md:text-sm">
@@ -169,7 +169,7 @@ $(document).ready(function() {
   href="/nonprofit/assets" 
   class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-transparent hover:border-white/75 hover:bg-white/10 flex-col text-white select-none "
   
-  title="/relations | /nonprofitassets"
+  title="/relationsindex | /nonprofitassets"
 >
   
   <strong class="md:text-sm">
@@ -185,9 +185,9 @@ $(document).ready(function() {
         </div>
         <a 
   href="/relations" 
-  class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-blue bg-blue/20 !text-white flex-col text-white select-none "
+  class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-transparent hover:border-white/75 hover:bg-white/10 flex-col text-white select-none "
   
-  title="/relations | /relations"
+  title="/relationsindex | /relations"
 >
   
   <strong class="md:text-sm">
@@ -222,7 +222,7 @@ $(document).ready(function() {
   href="/officers" 
   class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-transparent hover:border-white/75 hover:bg-white/10 flex-col text-white select-none "
   
-  title="/relations | /officers"
+  title="/relationsindex | /officers"
 >
   
   <strong class="md:text-sm">
@@ -238,7 +238,7 @@ $(document).ready(function() {
   href="/officers/bulk" 
   class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-transparent hover:border-white/75 hover:bg-white/10 flex-col text-white select-none "
   
-  title="/relations | /officersbulk"
+  title="/relationsindex | /officersbulk"
 >
   
   <strong class="md:text-sm">
@@ -273,7 +273,7 @@ $(document).ready(function() {
   href="/donations2024" 
   class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-transparent hover:border-white/75 hover:bg-white/10 flex-col text-white select-none "
   
-  title="/relations | /donations2024"
+  title="/relationsindex | /donations2024"
 >
   
   <strong class="md:text-sm">
@@ -289,7 +289,7 @@ $(document).ready(function() {
   href="/award_search" 
   class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-transparent hover:border-white/75 hover:bg-white/10 flex-col text-white select-none "
   
-  title="/relations | /award_search"
+  title="/relationsindex | /award_search"
 >
   
   <strong class="md:text-sm">
@@ -324,7 +324,7 @@ $(document).ready(function() {
   href="/florida" 
   class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-transparent hover:border-white/75 hover:bg-white/10 items-center gap-2 text-white/80 hover:text-white select-none "
   
-  title="/relations | /florida"
+  title="/relationsindex | /florida"
 >
   
     <span class="size-5 fill-current"><svg fill="fillCurrent" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 30 30">
@@ -344,7 +344,7 @@ $(document).ready(function() {
   href="/northcarolina" 
   class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-transparent hover:border-white/75 hover:bg-white/10 items-center gap-2 text-white/80 hover:text-white select-none "
   
-  title="/relations | /northcarolina"
+  title="/relationsindex | /northcarolina"
 >
   
     <span class="size-5 fill-current"><svg fill="fillCurrent" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 30 30">
@@ -364,7 +364,7 @@ $(document).ready(function() {
   href="/pennsylvania" 
   class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-transparent hover:border-white/75 hover:bg-white/10 items-center gap-2 text-white/80 hover:text-white select-none "
   
-  title="/relations | /pennsylvania"
+  title="/relationsindex | /pennsylvania"
 >
   
     <span class="size-5 fill-current"><svg class="opacity-80 group-hover:opacity-100" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24"
@@ -388,7 +388,7 @@ $(document).ready(function() {
   href="/donate" 
   class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-transparent hover:border-white/75 hover:bg-white/10 flex-col text-white select-none !border-green-light bg-green-light/20 hover:!bg-green-light hover:text-navy relative [&_.right-icon]:text-green-light"
   
-  title="/relations | /donate"
+  title="/relationsindex | /donate"
 >
   
   <strong class="md:text-sm">
@@ -406,7 +406,7 @@ $(document).ready(function() {
   href="https://x.com/datarepublican" 
   class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-transparent hover:border-white/75 hover:bg-white/10 flex-col text-white select-none relative "
   target="_blank"
-  title="/relations | /https:x.comdatarepublican"
+  title="/relationsindex | /https:x.comdatarepublican"
 >
   
   <strong class="md:text-sm">
@@ -424,7 +424,7 @@ $(document).ready(function() {
   href="/christianity" 
   class="nav-item group flex no-underline py-1.5 px-3 rounded focus:outline focus:outline-2 focus:outline-blue focus:outline-offset-2 border-2 border-transparent hover:border-white/75 hover:bg-white/10 flex-col text-white select-none "
   
-  title="/relations | /christianity"
+  title="/relationsindex | /christianity"
 >
   
   <strong class="md:text-sm">
@@ -985,7 +985,7 @@ It shows the generated graph and a legend, plus a button to go back to the searc
 
 <!-- Where the graph renders -->
 <div id="graph-container" class="border rounded flex items-center justify-center bg-white">
-  <svg id="graph" width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
+  <svg id="graph" width="100%" height="100%">
     <defs>
       <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
         markerWidth="6" markerHeight="6" orient="auto-start-reverse">
@@ -1864,11 +1864,6 @@ function initializeD3Graph() {
   width = container.clientWidth;
   height = container.clientHeight;
   
-  // Set the SVG viewBox to cover the entire container
-  d3.select('#graph')
-    .attr('viewBox', `${-width/2} ${-height/2} ${width} ${height}`)
-    .attr('preserveAspectRatio', 'xMidYMid meet');
-  
   // Initialize zoom behavior
   zoom = d3.zoom()
     .scaleExtent([0.1, 2])
@@ -1881,7 +1876,7 @@ function initializeD3Graph() {
     .call(zoom)
     .on('dblclick.zoom', null); // Disable double-click zoom
     
-  // Center the graph with a moderate scale factor
+  // Reset zoom and pan with initial scale of 0.7 to show more of the graph
   resetZoom();
   
   // Show loading indicator
@@ -1889,10 +1884,10 @@ function initializeD3Graph() {
 }
 
 function resetZoom() {
-  // Center the graph with an appropriate scale
+  // Start with a zoomed-out view (scale 0.7) to show more of the graph
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(0, 0).scale(0.8)
+    d3.zoomIdentity.translate(width/2, height/2).scale(0.7)
   );
 }
 
@@ -1925,14 +1920,11 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Reset zoom and pan with centered graph
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(0, 0).scale(0.8) // Center at origin
+    d3.zoomIdentity.translate(width/2, height/2).scale(0.7) // Increased scale for better visibility
   );
   
-  // Create the graph content group with initial transform
+  // Create the graph content group with initial transform to center it
   const g = d3.select('#graph-content');
-  
-  // Explicitly set an initial transform on the graph content to center it
-  g.attr('transform', `translate(${width/2}, ${height/2})`);
   
   // Store the root subject for reference in other functions
   window.rootSubject = rootSubject;
@@ -1947,22 +1939,22 @@ function renderD3Graph(rootSubject, nodes, edges) {
     nodeMap.set(node.id, node);
   });
   
-  // Pre-position nodes in a structured layout
-  // Position root node in the center
+  // Pre-position nodes in a structured layout for better initial placement
+  // Position root node in the center of the canvas
   if (rootNode) {
-    rootNode.x = 0; // Position at origin (will be transformed to center)
-    rootNode.y = 0; // Position at origin (will be transformed to center)
-    rootNode.fx = 0; // Fix position at origin
-    rootNode.fy = 0; // Fix position at origin
+    rootNode.x = width / 2;
+    rootNode.y = height / 2; 
+    rootNode.fx = rootNode.x; // Fix position
+    rootNode.fy = rootNode.y;
   }
   
-  // Arrange non-root nodes in a circle around the root node at the origin
-  const radius = Math.min(width, height) * 0.25; // Use 25% of the smaller dimension for radius
+  // Arrange non-root nodes in a circular pattern around the root node
+  const radius = Math.min(width, height) * 0.35; // Radius for node distribution
   nonRootNodes.forEach((node, i) => {
     const angle = (i * 2 * Math.PI) / nonRootNodes.length;
-    node.x = radius * Math.cos(angle); // Position relative to origin
-    node.y = radius * Math.sin(angle); // Position relative to origin
-    // Don't fix these positions completely, allow force layout to adjust
+    node.x = width/2 + radius * Math.cos(angle);
+    node.y = height/2 + radius * Math.sin(angle);
+    // Don't fix these positions completely, but use them as starting points
   });
   
   // Preprocess edges to ensure all source and target nodes exist
@@ -2292,17 +2284,17 @@ function renderD3Graph(rootSubject, nodes, edges) {
           
           if (!sourceNode || !targetNode) {
             console.warn("Missing node in link distance calculation");
-            return forceParams.linkDistance * 1.5; // Moderately increased distance
+            return forceParams.linkDistance * 2.0; // Further increased distance
           }
           
           const sourceSize = Math.sqrt(getNodeWidth(sourceNode) * getNodeHeight(sourceNode));
           const targetSize = Math.sqrt(getNodeWidth(targetNode) * getNodeHeight(targetNode));
           
           // Base distance on node sizes plus padding - increased for better spacing
-          return (sourceSize + targetSize) / 2 + forceParams.linkDistance;
+          return (sourceSize + targetSize) / 2 + forceParams.linkDistance * 2.0; // Further increased distance multiplier
         } catch (error) {
           console.error("Error in link distance calculation:", error, d);
-          return forceParams.linkDistance * 1.5; // Moderately increased default distance
+          return forceParams.linkDistance * 2.0; // Further increased default distance
         }
       })
     )
@@ -2310,56 +2302,30 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .strength(d => {
         // Stronger repulsion for structured layout
         const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
-        return forceParams.charge * (nodeSize / 200) * 1.5; // Moderately increased repulsion
+        return forceParams.charge * (nodeSize / 200) * 2.5; // Further increased repulsion
       })
       .distanceMin(300) // Further increased minimum distance
       .distanceMax(3000)) // Further increased maximum distance
-    .force('x', d3.forceX(0).strength(0.2)) // Center nodes horizontally at origin
-    .force('y', d3.forceY(0).strength(0.2)) // Center nodes vertically at origin
+    .force('x', d3.forceX(d => {
+      // Keep root node centered, let others spread horizontally
+      if (d.id === rootSubject) return width / 2;
+      return d.x; // Use pre-positioned x value
+    }).strength(d => d.id === rootSubject ? 1 : 0.1)) // Further reduced strength to allow more movement
+    .force('y', d3.forceY(d => {
+      // Keep root node at top, others in row below
+      if (d.id === rootSubject) return height * 0.2;
+      return height * 0.7;
+    }).strength(0.15)) // Further reduced strength to allow more movement
     .force('collision', d3.forceCollide().radius(d => {
       // Make collision radius based on node size plus padding
       const nodeWidth = getNodeWidth(d);
       const nodeHeight = getNodeHeight(d);
-      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 100; // Increased padding significantly
-    }).strength(0.8))
-    .alpha(0.8) // Higher alpha for more movement
-    .alphaDecay(0.01) // Slower decay for more time to find optimal positions
+      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 120; // Further increased padding significantly
+    }).strength(1))
+    .alpha(0.9) // Higher alpha for more movement
+    .alphaDecay(0.005) // Slower decay for more time to find optimal positions
     .velocityDecay(0.4)
-    .on('tick', ticked)
-    .on('end', () => {
-      // When the simulation ends, center the graph based on actual content bounds
-      centerGraph();
-    });
-}
-
-// Function to center the graph based on its actual rendered bounds
-function centerGraph() {
-  try {
-    // Get the bounding box of the graph content
-    const bbox = document.getElementById('graph-content').getBBox();
-    
-    // Calculate the center of the graph content
-    const graphCenterX = bbox.x + bbox.width / 2;
-    const graphCenterY = bbox.y + bbox.height / 2;
-    
-    // Calculate the translation needed to center the graph
-    const translateX = width / 2 - graphCenterX;
-    const translateY = height / 2 - graphCenterY;
-    
-    // Update the zoom transform to center the graph
-    d3.select('#graph').call(
-      zoom.transform,
-      d3.zoomIdentity.translate(translateX, translateY).scale(0.8)
-    );
-    
-    console.log('Graph centered based on actual bounds:', { 
-      bbox, 
-      graphCenter: { x: graphCenterX, y: graphCenterY },
-      translation: { x: translateX, y: translateY }
-    });
-  } catch (error) {
-    console.error('Error centering graph:', error);
-  }
+    .on('tick', ticked);
 }
 
 // Update the ticked function to properly position nodes, links, and labels
@@ -2367,11 +2333,9 @@ function ticked() {
   try {
     // Update node positions
     nodeElements.attr('transform', d => {
-      // Constrain to bounds relative to origin
-      const halfWidth = width / 2;
-      const halfHeight = height / 2;
-      d.x = Math.max(-halfWidth + 50, Math.min(halfWidth - 50, d.x));
-      d.y = Math.max(-halfHeight + 50, Math.min(halfHeight - 50, d.y));
+      // Constrain to bounds
+      d.x = Math.max(50, Math.min(width - 50, d.x));
+      d.y = Math.max(50, Math.min(height - 50, d.y));
       return `translate(${d.x - getNodeWidth(d) / 2}, ${d.y - getNodeHeight(d) / 2})`;
     });
     

--- a/docs/tip.html
+++ b/docs/tip.html
@@ -2,10 +2,10 @@
 <html lang="en-US">
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
-  <link rel="canonical" href="https://datarepublican.com/donate/">
-  <script>location="https://datarepublican.com/donate/"</script>
-  <meta http-equiv="refresh" content="0; url=https://datarepublican.com/donate/">
+  <link rel="canonical" href="http://localhost:4000/donate/">
+  <script>location="http://localhost:4000/donate/"</script>
+  <meta http-equiv="refresh" content="0; url=http://localhost:4000/donate/">
   <meta name="robots" content="noindex">
   <h1>Redirecting&hellip;</h1>
-  <a href="https://datarepublican.com/donate/">Click here if you are not redirected.</a>
+  <a href="http://localhost:4000/donate/">Click here if you are not redirected.</a>
 </html>

--- a/relations/index.html
+++ b/relations/index.html
@@ -301,14 +301,14 @@ let globalActiveCategories = new Set(); // which categories are currently on dis
 
 // Force simulation parameters
 const forceParams = {
-  linkDistance: 400,
-  charge: -3000,
-  collisionRadius: 200,
+  linkDistance: 600,     // Increased from 400
+  charge: -5000,         // Increased from -3000
+  collisionRadius: 300,  // Increased from 200
   bounds: {
-    left: 100,
-    right: 100,
-    top: 100,
-    bottom: 100
+    left: 150,
+    right: 150,
+    top: 150,
+    bottom: 150
   }
 };
 
@@ -1084,7 +1084,7 @@ function initializeD3Graph() {
     .call(zoom)
     .on('dblclick.zoom', null); // Disable double-click zoom
     
-  // Reset zoom and pan
+  // Reset zoom and pan with initial scale of 0.7 to show more of the graph
   resetZoom();
   
   // Show loading indicator
@@ -1092,9 +1092,10 @@ function initializeD3Graph() {
 }
 
 function resetZoom() {
+  // Start with a zoomed-out view (scale 0.7) to show more of the graph
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(width/2, height/2)
+    d3.zoomIdentity.translate(width/2, height/2).scale(0.7)
   );
 }
 
@@ -1698,135 +1699,143 @@ function ticked() {
   }
 }
 
-// Function to prevent label overlaps with nodes
+// Function to prevent label overlaps with nodes and other labels
 function preventLabelOverlaps() {
   try {
-    // For each label, check if it overlaps with any node
+    // First collect all node rectangles for overlap checking
+    const nodeRects = [];
+    nodeElements.each(function(d) {
+      nodeRects.push({
+        x: d.x - getNodeWidth(d) / 2,
+        y: d.y - getNodeHeight(d) / 2,
+        width: getNodeWidth(d),
+        height: getNodeHeight(d),
+        id: d.id
+      });
+    });
+    
+    // Collect all label rectangles
+    const labelRects = [];
     labelElements.each(function(d) {
-      try {
-        const labelGroup = d3.select(this);
-        const labelBg = labelGroup.select('.label-bg');
-        
-        // Skip if no background element
-        if (labelBg.empty()) return;
-        
-        // Get the label's bounding box
-        const labelBBox = labelBg.node().getBBox();
-        if (!labelBBox) return;
-        
-        // Current label position
-        const labelX = d.labelX || 0;
-        const labelY = d.labelY || 0;
-        
-        // Create a rectangle representing the label's current position
-        const labelRect = {
-          x: labelX - labelBBox.width / 2,
-          y: labelY - labelBBox.height / 2,
-          width: labelBBox.width,
-          height: labelBBox.height
-        };
+      const labelGroup = d3.select(this);
+      const labelBg = labelGroup.select('.label-bg');
+      
+      // Skip if no background element
+      if (labelBg.empty()) return;
+      
+      // Get the label's bounding box
+      const labelBBox = labelBg.node().getBBox();
+      if (!labelBBox) return;
+      
+      // Current label position
+      const labelX = d.labelX || 0;
+      const labelY = d.labelY || 0;
+      
+      labelRects.push({
+        x: labelX - labelBBox.width / 2,
+        y: labelY - labelBBox.height / 2,
+        width: labelBBox.width,
+        height: labelBBox.height,
+        edge: d,
+        group: labelGroup,
+        originalX: labelX,
+        originalY: labelY
+      });
+    });
+    
+    // Process each label to avoid overlaps
+    for (let i = 0; i < labelRects.length; i++) {
+      const labelRect = labelRects[i];
+      let hasOverlap = true;
+      let attempts = 0;
+      const maxAttempts = 10;
+      
+      // Try to find a position without overlaps
+      while (hasOverlap && attempts < maxAttempts) {
+        hasOverlap = false;
+        attempts++;
         
         // Check for overlaps with nodes
-        let maxOverlap = 0;
-        nodeElements.each(function(nodeData) {
-          const nodeRect = {
-            x: nodeData.x - getNodeWidth(nodeData) / 2,
-            y: nodeData.y - getNodeHeight(nodeData) / 2,
-            width: getNodeWidth(nodeData),
-            height: getNodeHeight(nodeData)
-          };
-          
-          // Calculate overlap area
-          const overlapArea = calculateOverlapArea(labelRect, nodeRect);
-          maxOverlap = Math.max(maxOverlap, overlapArea);
-        });
-        
-        // If there's significant overlap, try to reposition the label
-        if (maxOverlap > 0) {
-          // Get source and target IDs
-          const sourceId = d.from;
-          const targetId = d.to;
-          
-          if (!sourceId || !targetId) return;
-          
-          // Find the path for this label
-          let path = d.path;
-          
-          // If path is not stored, try to find it
-          if (!path) {
-            path = d3.select(`path[data-source="${sourceId}"][data-target="${targetId}"]`).node();
-            if (!path) {
-              console.log('No path found for label:', sourceId, targetId);
-              return;
-            }
-            d.path = path;
-          }
-          
-          const pathLength = path.getTotalLength();
-          if (!pathLength || pathLength <= 0) {
-            console.log('Invalid path length:', pathLength);
-            return;
-          }
-          
-          // Try different positions along the path
-          let bestPosition = 0.5; // Default to midpoint
-          let minOverlap = maxOverlap;
-          
-          // Test positions at 5% increments
-          for (let pos = 0.05; pos <= 0.95; pos += 0.05) {
-            if (pos === 0.5) continue; // Skip the current position
+        for (const nodeRect of nodeRects) {
+          if (rectsOverlap(labelRect, nodeRect)) {
+            hasOverlap = true;
             
-            const testPoint = path.getPointAtLength(pathLength * pos);
-            
-            // Create a rectangle for this test position
-            const testRect = {
-              x: testPoint.x - labelBBox.width / 2,
-              y: testPoint.y - labelBBox.height / 2,
-              width: labelBBox.width,
-              height: labelBBox.height
-            };
-            
-            // Check overlap with all nodes
-            let testMaxOverlap = 0;
-            nodeElements.each(function(nodeData) {
-              const nodeRect = {
-                x: nodeData.x - getNodeWidth(nodeData) / 2,
-                y: nodeData.y - getNodeHeight(nodeData) / 2,
-                width: getNodeWidth(nodeData),
-                height: getNodeHeight(nodeData)
-              };
-              
-              const overlapArea = calculateOverlapArea(testRect, nodeRect);
-              testMaxOverlap = Math.max(testMaxOverlap, overlapArea);
-            });
-            
-            // If this position has less overlap, use it
-            if (testMaxOverlap < minOverlap) {
-              minOverlap = testMaxOverlap;
-              bestPosition = pos;
-            }
-          }
-          
-          // If we found a better position, update the label
-          if (bestPosition !== 0.5) {
-            const newPoint = path.getPointAtLength(pathLength * bestPosition);
-            
-            // Update stored position
-            d.labelX = newPoint.x;
-            d.labelY = newPoint.y;
-            
-            // Update transform
-            labelGroup.attr('transform', `translate(${newPoint.x}, ${newPoint.y})`);
-            
-            console.log('Repositioned label to reduce overlap:', sourceId, targetId, bestPosition);
+            // Try to move the label away from the node
+            repositionLabelAwayFromRect(labelRect, nodeRect);
+            break;
           }
         }
-      } catch (error) {
-        console.error("Error in label overlap prevention for label:", error, d);
+        
+        // If no node overlaps, check for overlaps with other labels
+        if (!hasOverlap) {
+          for (let j = 0; j < i; j++) {
+            if (rectsOverlap(labelRect, labelRects[j])) {
+              hasOverlap = true;
+              
+              // Try to move the label away from the other label
+              repositionLabelAwayFromRect(labelRect, labelRects[j]);
+              break;
+            }
+          }
+        }
       }
-    });
+      
+      // Update the label position
+      labelRect.group.attr('transform', `translate(${labelRect.x + labelRect.width/2}, ${labelRect.y + labelRect.height/2})`);
+      
+      // Update stored position for future reference
+      labelRect.edge.labelX = labelRect.x + labelRect.width/2;
+      labelRect.edge.labelY = labelRect.y + labelRect.height/2;
+    }
   } catch (error) {
     console.error("Error in preventLabelOverlaps:", error);
+  }
+}
+
+// Helper function to check if two rectangles overlap
+function rectsOverlap(rect1, rect2) {
+  return !(
+    rect1.x + rect1.width < rect2.x ||
+    rect2.x + rect2.width < rect1.x ||
+    rect1.y + rect1.height < rect2.y ||
+    rect2.y + rect2.height < rect1.y
+  );
+}
+
+// Helper function to reposition a label away from an overlapping rectangle
+function repositionLabelAwayFromRect(labelRect, overlapRect) {
+  // Calculate centers
+  const labelCenterX = labelRect.x + labelRect.width / 2;
+  const labelCenterY = labelRect.y + labelRect.height / 2;
+  const rectCenterX = overlapRect.x + overlapRect.width / 2;
+  const rectCenterY = overlapRect.y + overlapRect.height / 2;
+  
+  // Calculate direction vector from overlapping rect to label
+  const dirX = labelCenterX - rectCenterX;
+  const dirY = labelCenterY - rectCenterY;
+  
+  // Normalize direction vector
+  const length = Math.sqrt(dirX * dirX + dirY * dirY);
+  const normDirX = length > 0 ? dirX / length : 0;
+  const normDirY = length > 0 ? dirY / length : 1; // Default to moving down if centers are the same
+  
+  // Calculate minimum distance needed to avoid overlap
+  const minDistX = (labelRect.width + overlapRect.width) / 2;
+  const minDistY = (labelRect.height + overlapRect.height) / 2;
+  
+  // Move primarily in the direction with the least overlap
+  const overlapX = minDistX - Math.abs(labelCenterX - rectCenterX);
+  const overlapY = minDistY - Math.abs(labelCenterY - rectCenterY);
+  
+  // Add a small buffer to ensure no overlap
+  const buffer = 10;
+  
+  if (overlapX < overlapY) {
+    // Move horizontally
+    labelRect.x += (overlapX + buffer) * Math.sign(normDirX);
+  } else {
+    // Move vertically
+    labelRect.y += (overlapY + buffer) * Math.sign(normDirY);
   }
 }
 

--- a/relations/index.html
+++ b/relations/index.html
@@ -2951,24 +2951,7 @@ function getNodeLayer(nodeId, edgesParam) {
   return 3; // Everything else is layer 3 or beyond
 }
 
-// Add text to labels
-labelElements.append('text')
-  .attr('class', 'link-label')
-  .attr('text-anchor', 'middle')
-  .attr('dominant-baseline', 'middle')
-  .attr('fill', '#374151')
-  .style('pointer-events', 'none')
-  .style('font-size', '12px')
-  .style('font-weight', 'bold')
-  .text(function(d) {
-    // For "Son of" relationships, highlight them with a special format
-    if (d.label && (d.label.includes("Son of") || d.label.includes("Child of") || 
-                    d.label.includes("Parent of") || d.label.includes("Father of") || 
-                    d.label.includes("Mother of"))) {
-      return d.label;
-    }
-    return d.label || '';
-  });
+
 </script>
 </body>
 </html>

--- a/relations/index.html
+++ b/relations/index.html
@@ -1289,9 +1289,13 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Add text to nodes
   nodeElements.each(function(d) {
     const node = d3.select(this);
-    const bulletInfo = d.bulletInfo;
-    const padding = 10;
+    const bulletInfo = d.bulletInfo || {};
+    const padding = 12;
     let y = padding;
+    
+    // Calculate node width for text wrapping
+    const nodeWidth = getNodeWidth(d);
+    const maxCharsPerLine = Math.floor((nodeWidth - padding * 2) / 6.5); // Adjusted chars per line
     
     // Add subject name
     node.append('text')
@@ -1304,7 +1308,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     
     // Add bullet point 1 if available
     if (bulletInfo && bulletInfo.bullet_point1) {
-      const wrappedText = wrapText(bulletInfo.bullet_point1, 30);
+      const wrappedText = wrapText(bulletInfo.bullet_point1, maxCharsPerLine);
       wrappedText.forEach(line => {
         node.append('text')
           .attr('x', padding)
@@ -1318,7 +1322,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     // Add bullet point 2 if available
     if (bulletInfo && bulletInfo.bullet_point2) {
       y += 5; // Add a little extra space
-      const wrappedText = wrapText(bulletInfo.bullet_point2, 30);
+      const wrappedText = wrapText(bulletInfo.bullet_point2, maxCharsPerLine);
       wrappedText.forEach(line => {
         node.append('text')
           .attr('x', padding)
@@ -1935,23 +1939,29 @@ function getNodeWidth(node) {
     const bullet1 = bulletInfo.bullet_point1 || '';
     const bullet2 = bulletInfo.bullet_point2 || '';
     
-    // Find the longest line after wrapping
-    const wrappedBullet1 = wrapText(bullet1, 30);
-    const wrappedBullet2 = wrapText(bullet2, 30);
+    // If there are no bullet points, use a smaller width
+    if (bullet1.length === 0 && bullet2.length === 0) {
+      node._width = Math.max(textLength * 8 + 40, 120);
+      return node._width;
+    }
     
-    let maxLineLength = textLength;
-    wrappedBullet1.forEach(line => {
-      maxLineLength = Math.max(maxLineLength, line.length);
-    });
-    wrappedBullet2.forEach(line => {
-      maxLineLength = Math.max(maxLineLength, line.length);
-    });
+    // For nodes with descriptions, calculate width based on content
+    // Find the longest line in the bullets
+    const longestBullet = bullet1.length > bullet2.length ? bullet1 : bullet2;
     
-    // Calculate width based on the longest text
-    node._width = Math.max(
-      Math.min(maxLineLength * 8, 350),
-      150
+    // Estimate how many characters we can fit per line
+    // Use a smaller character width to fit more text per line
+    const charWidth = 6.5; // Pixels per character (reduced to fit more text)
+    
+    // Calculate a width that will fit approximately 40-50 chars per line
+    // This ensures text fills the box better
+    const targetCharsPerLine = 45;
+    const contentBasedWidth = Math.min(
+      Math.max(longestBullet.length, textLength * 1.5) * charWidth + 40,
+      targetCharsPerLine * charWidth + 40
     );
+    
+    node._width = Math.max(contentBasedWidth, 220);
   }
   return node._width;
 }
@@ -1965,19 +1975,33 @@ function getNodeHeight(node) {
     const bullet1 = bulletInfo.bullet_point1 || '';
     const bullet2 = bulletInfo.bullet_point2 || '';
     
+    // Use consistent padding (12px) for top, sides, and bottom
+    const padding = 12;
+    
+    // If there are no bullet points, use a smaller height but maintain padding
+    if (bullet1.length === 0 && bullet2.length === 0) {
+      node._height = padding + 18 + padding; // Top padding + title height + bottom padding
+      return node._height;
+    }
+    
+    // Get node width to calculate how many lines we'll need
+    const nodeWidth = getNodeWidth(node);
+    const charsPerLine = Math.floor((nodeWidth - padding * 2) / 6.5); // Characters per line
+    
     // Count lines after wrapping
-    const wrappedBullet1 = wrapText(bullet1, 30);
-    const wrappedBullet2 = wrapText(bullet2, 30);
+    const wrappedBullet1 = wrapText(bullet1, charsPerLine);
+    const wrappedBullet2 = wrapText(bullet2, charsPerLine);
     
     const bulletLines1 = wrappedBullet1.length;
     const bulletLines2 = wrappedBullet2.length;
     
     // Calculate height based on number of lines
-    node._height = 30 + (bulletLines1 + bulletLines2) * 18;
+    // Top padding + title height + bullet points + bottom padding
+    node._height = padding + 18 + (bulletLines1 + bulletLines2) * 18 + padding;
     
-    // Add extra padding if there are two bullet points
+    // Add small padding between bullet points if both exist
     if (bulletLines1 > 0 && bulletLines2 > 0) {
-      node._height += 10;
+      node._height += 5;
     }
     
     // Ensure minimum height
@@ -1988,13 +2012,30 @@ function getNodeHeight(node) {
 
 // Helper function to wrap text to a specified width
 function wrapText(text, maxChars) {
-  if (!text) return [''];
+  if (!text) return [];
   
   const words = text.split(' ');
   const lines = [];
   let currentLine = '';
   
   words.forEach(word => {
+    // If the word itself is longer than maxChars, we need to break it
+    if (word.length > maxChars) {
+      // First add any current line content
+      if (currentLine) {
+        lines.push(currentLine);
+        currentLine = '';
+      }
+      
+      // Then break the long word
+      let i = 0;
+      while (i < word.length) {
+        lines.push(word.substr(i, maxChars));
+        i += maxChars;
+      }
+      return;
+    }
+    
     const testLine = currentLine ? `${currentLine} ${word}` : word;
     if (testLine.length <= maxChars) {
       currentLine = testLine;

--- a/relations/index.html
+++ b/relations/index.html
@@ -41,7 +41,6 @@ title: People Relations (BETA)
     display: flex;     /* Add flexbox to center content */
     justify-content: center; /* Center horizontally */
     align-items: flex-start; /* Align to the top instead of center */
-    padding-top: 20px; /* Add some padding at the top */
   }
   #legend {
     display: flex;
@@ -70,12 +69,6 @@ title: People Relations (BETA)
     fill: none;
     stroke-width: 2px;
     filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.05));
-  }
-  .label-bg {
-    fill: #F3F4F6;
-    stroke: white;
-    stroke-width: 2px;
-    filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.1));
   }
   .link-label {
     fill: #475569;
@@ -1478,6 +1471,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .attr('ry', 12)
     .attr('class', 'label-bg')
     .attr('fill', '#F3F4F6')
+    .attr('stroke', '#94A3B8')
     .attr('width', 10) // Initial size, will be updated in ticked
     .attr('height', 10)
     .attr('x', -5)

--- a/relations/index.html
+++ b/relations/index.html
@@ -269,13 +269,16 @@ It shows the generated graph and a legend, plus a button to go back to the searc
     <g id="graph-content"></g>
   </svg>
   <!-- Add loading overlay with the same styling as in expose/index.html -->
-  <div id="loading" class="absolute inset-0 flex flex-col items-center justify-center pt-5 bg-white z-30">
+  <div id="loading" class="absolute inset-0 flex flex-col items-center justify-start pt-16 bg-white z-30">
     <div class="text-center">
       <svg class="animate-spin h-8 w-8 text-navy mx-auto mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
         <path fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
       </svg>
       <div id="loading-text" class="text-lg font-semibold text-navy mb-4">Loading graph...</div>
+      <div id="loading-nodes" class="text-gray-600 max-w-md mx-auto text-center max-h-[50vh] overflow-y-auto px-4">
+        <!-- Node names will be added here -->
+      </div>
     </div>
   </div>
   <div id="loading-indicator" class="absolute">
@@ -1192,14 +1195,8 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Update loading text to show that the graph is being processed
   $('#loading-text').text('Rendering graph visualization...');
   
-  // Add a timeout to ensure loading overlay is hidden even if other mechanisms fail
-  setTimeout(() => {
-    console.log("Timeout check - ensuring loading overlay is hidden");
-    if (document.getElementById('loading')) {
-      document.getElementById('loading').style.display = 'none';
-    }
-    $('#loading-indicator').hide();
-  }, 10000); // 10 seconds should be plenty for the graph to render
+  // Remove the premature timeout - we'll let the centerGraph function handle hiding the overlay
+  // instead of this fixed 10-second timer
   
   // Initialize container dimensions
   const container = document.getElementById('graph-container');
@@ -1299,7 +1296,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
   console.log(`Filtered to ${validEdges.length} valid edges`);
   
   // Identify first-level nodes (directly connected to root)
-  const firstLevelNodeIds = new Set();
+  window.firstLevelNodeIds = new Set();
   validEdges.forEach(edge => {
     if (edge.from === rootSubject) {
       firstLevelNodeIds.add(edge.to);
@@ -1312,6 +1309,8 @@ function renderD3Graph(rootSubject, nodes, edges) {
   
   console.log(`Identified ${firstLevelNodeIds.size} first-level nodes`);
   console.log('First-level nodes:', Array.from(firstLevelNodeIds));
+  
+  // We'll call displayNodesProgressively() after nodeElements is defined
   
   // Add arrow markers for links
   const defs = g.append('defs');
@@ -1390,6 +1389,9 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .on('end', dragEnded)
     );
    
+  // Start displaying first-level nodes progressively now that nodeElements is defined
+  displayNodesProgressively();
+  
   // Add rectangles to nodes
   nodeElements.append('rect')
     .attr('rx', 4)
@@ -1822,12 +1824,83 @@ function renderD3Graph(rootSubject, nodes, edges) {
       // When the simulation ends, center the graph based on actual content bounds
       centerGraph();
       
-      // Failsafe: directly hide loading elements in case centerGraph didn't do it
-      console.log("Simulation ended - ensuring loading overlay is hidden");
-      document.getElementById('loading').style.display = 'none';
-      $('#loading-indicator').hide();
-      $('#loading-overlay').hide();
+      // We'll move the progressive display and failsafe to after centerGraph completes
+      // by letting centerGraph call displayNodesProgressively
     });
+}
+
+// Function to display nodes progressively after data is fully loaded
+function displayNodesProgressively() {
+  try {
+    const loadingNodesDiv = document.getElementById('loading-nodes');
+    if (!loadingNodesDiv) {
+      console.warn("Loading nodes div not found");
+      return;
+    }
+    
+    loadingNodesDiv.innerHTML = ''; // Clear any existing content
+    
+    // Check if nodeElements exists - if not, we can't display nodes yet
+    if (!nodeElements) {
+      console.warn("Node elements not available yet, cannot display nodes progressively");
+      return;
+    }
+    
+    // Get root node
+    const rootNode = nodeElements.filter(d => d.id === rootSubject).data()[0];
+    
+    // Find first-level nodes (directly connected to root)
+    // Use window.firstLevelNodeIds to ensure we access the global variable
+    const firstLevelNodes = nodeElements.filter(d => window.firstLevelNodeIds.has(d.id)).data();
+    
+    console.log(`Displaying ${firstLevelNodes.length} first-level nodes progressively`);
+    
+    // Add root node first
+    if (rootNode) {
+      const rootDiv = document.createElement('div');
+      rootDiv.className = 'font-bold opacity-0 transition-opacity duration-300 py-1';
+      rootDiv.textContent = rootNode.id;
+      loadingNodesDiv.appendChild(rootDiv);
+      
+      // Trigger fade in for root node
+      setTimeout(() => {
+        rootDiv.style.opacity = '1';
+      }, 100);
+    }
+    
+    // Add first-level nodes progressively
+    let nodeIndex = 0;
+    function addNextNode() {
+      if (nodeIndex < firstLevelNodes.length) {
+        const node = firstLevelNodes[nodeIndex];
+        
+        // Create element for this node
+        const div = document.createElement('div');
+        div.className = 'opacity-0 transition-opacity duration-300 py-1';
+        div.textContent = node.id;
+        
+        // Add to container
+        loadingNodesDiv.appendChild(div);
+        
+        // Trigger fade in and scroll to bottom
+        setTimeout(() => {
+          div.style.opacity = '1';
+          loadingNodesDiv.scrollTop = loadingNodesDiv.scrollHeight;
+        }, 50);
+        
+        // Move to next node
+        nodeIndex++;
+        
+        // Schedule next node with 1 second delay
+        setTimeout(addNextNode, 1000);
+      }
+    }
+    
+    // Start adding nodes with a short delay
+    setTimeout(addNextNode, 500);
+  } catch (error) {
+    console.error("Error displaying nodes progressively:", error);
+  }
 }
 
 // Function to center the graph based on its actual rendered bounds
@@ -1871,14 +1944,21 @@ function centerGraph() {
         .scale(initialScale)
     );
     
+    console.log("Graph centered based on actual bounds");
+    
+    // Now the nodes are already being displayed progressively before centering
+    // so we don't need to call displayNodesProgressively here
+    
     // Hide loading overlay and indicators
     document.getElementById('loading').style.display = 'none';
     $('#loading-indicator').hide();
     $('#loading-overlay').fadeOut();
-    
-    console.log("Loading overlay hidden");
   } catch (error) {
     console.error("Error centering graph:", error);
+    
+    // Failsafe: Ensure loading overlay is hidden even if there's an error
+    document.getElementById('loading').style.display = 'none';
+    $('#loading-indicator').hide();
   }
 }
 

--- a/relations/index.html
+++ b/relations/index.html
@@ -265,7 +265,7 @@ It shows the generated graph and a legend, plus a button to go back to the searc
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
         <path fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
       </svg>
-      <div id="loading-text" class="text-lg font-semibold text-navy mb-4">Loading graph...</div>
+      <div id="loading-text" class="text-lg font-semibold text-navy">Loading data...</div>
       <div id="loading-nodes" class="text-gray-600 max-w-md mx-auto text-center px-4 max-h-[80vh] overflow-y-auto">
         <!-- Node names will be added here -->
       </div>
@@ -1238,18 +1238,36 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Position root node at the top center
   if (rootNode) {
     rootNode.x = 0; // Center horizontally
-    rootNode.y = -height * 0.7; // Increased negative value to position even higher
+    rootNode.y = -height * 0.9; // Position much higher (was 0.7)
     rootNode.fx = 0; // Fix position horizontally
-    rootNode.fy = -height * 0.7; // Increased negative value to position even higher
+    rootNode.fy = -height * 0.9; // Fix position vertically (was 0.7)
   }
   
-  // Arrange non-root nodes in a semi-circle below the root node
-  const radius = Math.min(width, height) * 0.25; // Use 25% of the smaller dimension for radius
-  nonRootNodes.forEach((node, i) => {
-    // Use a semi-circle (180 degrees) below the root
-    const angle = (Math.PI * i) / (nonRootNodes.length - 1);
-    node.x = radius * Math.cos(angle); // Position in semi-circle
-    node.y = -height * 0.7 + radius * Math.sin(angle) + radius; // Position below root node
+  // Arrange non-root nodes in a tiered layout instead of a semi-circle
+  // First identify first-level nodes (directly connected to root)
+  const firstLevelIds = new Set();
+  edges.forEach(edge => {
+    if (edge.from === rootSubject) {
+      firstLevelIds.add(edge.to);
+    } else if (edge.to === rootSubject) {
+      firstLevelIds.add(edge.from);
+    }
+  });
+  
+  // Now position nodes in tiers
+  nonRootNodes.forEach(node => {
+    // Randomize x position slightly for each node
+    const xOffset = (Math.random() - 0.5) * width * 0.6;
+    
+    if (firstLevelIds.has(node.id)) {
+      // First tier - below root but in a more spread out arrangement
+      node.x = xOffset;
+      node.y = -height * 0.5; // First tier below root
+    } else {
+      // Second+ tier - further below
+      node.x = xOffset * 1.2; // Wider spread for lower tiers
+      node.y = -height * 0.1 + (Math.random() * height * 0.3); // Variable positions lower down
+    }
   });
   
   // Preprocess edges to ensure all source and target nodes exist
@@ -1380,7 +1398,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
    
   // Start displaying first-level nodes progressively now that nodeElements is defined
   displayNodesProgressively();
-  
+    
   // Add rectangles to nodes
   nodeElements.append('rect')
     .attr('rx', 4)
@@ -1494,18 +1512,18 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Add text labels with wrapping
   labelElements.each(function(d) {
     try {
-      const labelGroup = d3.select(this);
-      const label = d.label || "";
-      
-      // Skip empty labels
-      if (!label.trim()) {
-        labelGroup.append('text')
-          .attr('class', 'link-label')
-          .attr('fill', '#475569')
-          .text("");
-        return;
-      }
-      
+    const labelGroup = d3.select(this);
+    const label = d.label || "";
+    
+    // Skip empty labels
+    if (!label.trim()) {
+      labelGroup.append('text')
+        .attr('class', 'link-label')
+        .attr('fill', '#475569')
+        .text("");
+      return;
+    }
+    
       // For "Son of" relationship, use special styling and don't wrap
       const isSonOfRelation = label.includes("Son of") || label.includes("Child of") || 
                              label.includes("Parent of") || label.includes("Father of") || 
@@ -1522,17 +1540,17 @@ function renderD3Graph(rootSubject, nodes, edges) {
           .text(label);
       } else {
         // Wrap text to max 20 characters per line for other relationships
-        const wrappedText = wrapText(label, 20);
-        
-        // Add each line of text
-        wrappedText.forEach((line, i) => {
-          labelGroup.append('text')
-            .attr('class', 'link-label')
-            .attr('fill', '#475569')
-            .attr('text-anchor', 'middle') // Center text
-            .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
-            .text(line);
-        });
+    const wrappedText = wrapText(label, 20);
+    
+    // Add each line of text
+    wrappedText.forEach((line, i) => {
+      labelGroup.append('text')
+        .attr('class', 'link-label')
+        .attr('fill', '#475569')
+        .attr('text-anchor', 'middle') // Center text
+        .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
+        .text(line);
+    });
       }
       
       if (!d.pathPoints) {
@@ -1742,17 +1760,25 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .force('x', d3.forceX(d => {
       if (d.id === rootSubject) return 0;
       if (firstLevelNodeIds.has(d.id)) {
-        return d.x * 1.7; // Push first level nodes further out horizontally
+        // Spread first level nodes horizontally
+        const index = Array.from(firstLevelNodeIds).indexOf(d.id);
+        const angleStep = Math.PI / Math.max(firstLevelNodeIds.size, 1);
+        const angle = (index * angleStep) - Math.PI/2;
+        return 300 * Math.cos(angle); // Circular arrangement
       }
-      return d.x;
-    }).strength(0.25))
+      return d.x * 0.5; // Weaker horizontal force for other nodes
+    }).strength(0.5))
     .force('y', d3.forceY(d => {
-      if (d.id === rootSubject) return -height * 0.7; // Increased negative value for higher positioning
+      if (d.id === rootSubject) return -height * 0.9; // Keep root very high
       if (firstLevelNodeIds.has(d.id)) {
-        return d.y; // Keep first level at their y positions
+        // Position first level nodes in a semi-circle below root
+        const index = Array.from(firstLevelNodeIds).indexOf(d.id);
+        const angleStep = Math.PI / Math.max(firstLevelNodeIds.size, 1);
+        const angle = (index * angleStep) - Math.PI/2;
+        return -height * 0.5 + 300 * Math.max(0, Math.sin(angle)); // Create arc below root
       }
-      return height * 0.35; // Push other nodes down more
-    }).strength(0.25))
+      return height * 0.2; // Push other nodes down more
+    }).strength(0.5)) // Stronger vertical force
     .force('collision', d3.forceCollide()
       .radius(d => {
         // Even larger collision radius to keep nodes well separated
@@ -1780,9 +1806,9 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .distance(d => {
         // Use different distances for different types of connections
         if (d.from === rootSubject || d.to === rootSubject) {
-          return forceParams.linkDistance * 8; // Reduced from 10
+          return forceParams.linkDistance * 12; // Increased from 8 to create more vertical separation
         }
-        return forceParams.linkDistance * 5; // Reduced from 7
+        return forceParams.linkDistance * 6; // Slightly increased for all other connections
       }))
     .force('charge', d3.forceManyBody()
       .strength(d => {
@@ -1800,26 +1826,32 @@ function renderD3Graph(rootSubject, nodes, edges) {
       // Root node stays at center
       if (d.id === rootSubject) return 0;
       
-      // First level nodes maintain their existing x position but with scaling
+      // First level nodes - spread them horizontally in an arc
       if (firstLevelNodeIds.has(d.id)) {
-        return d.x * 1.2; // Reduced from 1.3
+        const index = Array.from(firstLevelNodeIds).indexOf(d.id);
+        const angleStep = Math.PI / Math.max(firstLevelNodeIds.size, 1);
+        const angle = (index * angleStep) - Math.PI/2;
+        return 350 * Math.cos(angle); // Circular arrangement
       }
       
       // Second level nodes spread wider
-      return d.x * 1.3; // Reduced from 1.4
-    }).strength(d => d.id === rootSubject ? 1 : 0.3)) // Increased from 0.2 for faster positioning
+      return d.x * 1.2;
+    }).strength(d => d.id === rootSubject ? 1 : 0.5)) // Stronger force to maintain structure
     .force('y', d3.forceY(d => {
       // Keep root at top
-      if (d.id === rootSubject) return -height * 0.7; // Increased negative value for higher positioning
+      if (d.id === rootSubject) return -height * 0.9; // Position root very high
       
-      // First level nodes position
+      // First level nodes positioned in arc below root
       if (firstLevelNodeIds.has(d.id)) {
-        return d.y * 0.9; // Adjust as needed
+        const index = Array.from(firstLevelNodeIds).indexOf(d.id);
+        const angleStep = Math.PI / Math.max(firstLevelNodeIds.size, 1);
+        const angle = (index * angleStep) - Math.PI/2;
+        return -height * 0.5 + 300 * Math.max(0, Math.sin(angle)); // Semi-circular arrangement
       }
       
-      // Second level nodes position
-      return d.y * 1.2; // Reduced from 1.3
-    }).strength(d => d.id === rootSubject ? 1 : 0.4)) // Increased from 0.35
+      // Second level nodes positioned at bottom
+      return height * 0.3; // Push other nodes further down
+    }).strength(d => d.id === rootSubject ? 1 : 0.6)) // Stronger vertical force
     .force('collision', d3.forceCollide().radius(d => {
       // Use much larger collision radius
       const nodeWidth = getNodeWidth(d);
@@ -1875,10 +1907,10 @@ function displayNodesProgressively() {
       rootDiv.className = 'opacity-0 transition-opacity duration-300 py-1';
       
       // Add the root node ID as the main text
-      const nodeIdSpan = document.createElement('div');
-      nodeIdSpan.className = 'font-bold';
-      nodeIdSpan.textContent = rootNode.id;
-      rootDiv.appendChild(nodeIdSpan);
+      // const nodeIdSpan = document.createElement('div');
+      // nodeIdSpan.className = 'font-bold';
+      // nodeIdSpan.textContent = rootNode.id;
+      // rootDiv.appendChild(nodeIdSpan);
       
       // Add text indicating this is the root node
       const relationSpan = document.createElement('div');
@@ -2025,9 +2057,25 @@ function ticked() {
     simulation.nodes().forEach(d => {
       if (d.id === rootSubject) {
         d.x = 0;
-        d.y = -height * 0.5; // Increased to position higher (was 0.4)
+        d.y = -height * 0.9; // Position root much higher
         d.fx = 0;
-        d.fy = -height * 0.5; // Increased to position higher (was 0.4)
+        d.fy = -height * 0.9; // Position root much higher
+      }
+      
+      // Keep first level nodes in their semi-circular arrangement
+      if (firstLevelNodeIds.has(d.id)) {
+        // Limit vertical movement - first level nodes shouldn't go above a certain point
+        if (d.y < -height * 0.3) {
+          d.y = Math.max(d.y, -height * 0.3);
+        }
+      }
+      
+      // Enforce hierarchical layout - non-root nodes should never go above the root
+      if (d.id !== rootSubject) {
+        // Keep all non-root nodes below the root node by at least some margin
+        if (d.y < -height * 0.7) {
+          d.y = -height * 0.7;
+        }
       }
     });
     
@@ -2125,10 +2173,10 @@ function ticked() {
         
         // Direct line for debugging
         if (window.debugMode) {
-          const sourceX = sourceNode.x;
-          const sourceY = sourceNode.y;
-          const targetX = targetNode.x;
-          const targetY = targetNode.y;
+        const sourceX = sourceNode.x;
+        const sourceY = sourceNode.y;
+        const targetX = targetNode.x;
+        const targetY = targetNode.y;
           return `M${sourceX},${sourceY} L${targetX},${targetY}`;
         }
         
@@ -2234,7 +2282,7 @@ function ticked() {
             const cp2x = sourcePoint.x + dx * 0.9;
             const cp2y = sourcePoint.y + dy * (1 - randomOffset);
             
-            path = `M${sourcePoint.x},${sourcePoint.y} 
+          path = `M${sourcePoint.x},${sourcePoint.y} 
                     C${cp1x},${cp1y} ${cp2x},${cp2y} ${targetPoint.x},${targetPoint.y}`;
           } else if (Math.abs(sourceLayer - targetLayer) <= 1) {
             // Nodes are on similar layers - use a curved path
@@ -2245,7 +2293,7 @@ function ticked() {
             
             path = `M${sourcePoint.x},${sourcePoint.y} 
                     Q${midX},${midY} ${targetPoint.x},${targetPoint.y}`;
-          } else {
+        } else {
             // Significant horizontal distance - use orthogonal routing with randomized midpoints
             const midX = (sourcePoint.x + targetPoint.x) / 2 + 
                       ((sourceId.length * targetId.length) % 100 - 50);
@@ -2253,7 +2301,7 @@ function ticked() {
             const midY1 = sourcePoint.y + (isSourceHigher ? yDiff * 0.25 : -yDiff * 0.25);
             const midY2 = targetPoint.y + (isSourceHigher ? -yDiff * 0.25 : yDiff * 0.25);
             
-            path = `M${sourcePoint.x},${sourcePoint.y} 
+          path = `M${sourcePoint.x},${sourcePoint.y} 
                     C${sourcePoint.x},${midY1} ${midX},${midY1} ${midX},${(midY1 + midY2) / 2}
                     S${targetPoint.x},${midY2} ${targetPoint.x},${targetPoint.y}`;
           }
@@ -2388,9 +2436,9 @@ function ticked() {
           let labelHeight = 0;
           
           // Calculate total width and height based on all text elements
-          textElements.each(function() {
+        textElements.each(function() {
             try {
-              const bbox = this.getBBox();
+          const bbox = this.getBBox();
               labelWidth = Math.max(labelWidth, bbox.width);
               labelHeight += bbox.height;
             } catch (e) {

--- a/relations/index.html
+++ b/relations/index.html
@@ -6,9 +6,8 @@ title: People Relations (BETA)
 <!-- jQuery for convenience -->
 <script src="jquery.min.js"></script>
 
-<!-- Viz.js (core + full render) -->
-<script src="viz.js"></script>
-<script src="full.render.js"></script>
+<!-- D3.js -->
+<script src="https://d3js.org/d3.v7.min.js"></script>
 
 <!-- svg-pan-zoom for panning/zooming the resulting SVG -->
 <script src="svg-pan-zoom.min.js"></script>
@@ -47,6 +46,56 @@ title: People Relations (BETA)
     gap: 8px;
     margin-bottom: 0.5rem;
   }
+  
+  /* D3 Graph Styles */
+  .node rect {
+    fill: #F3F4F6;
+    stroke: #94A3B8;
+    stroke-width: 1px;
+    filter: drop-shadow(0px 2px 3px rgba(0, 0, 0, 0.1));
+  }
+  .node.root rect {
+    stroke: #2563EB;
+    stroke-width: 3px;
+    fill: #EFF6FF;
+  }
+  .node text {
+    pointer-events: none;
+  }
+  .link {
+    fill: none;
+    stroke: #CBD5E1;
+    stroke-width: 2px;
+    filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.05));
+  }
+  .arrow-path {
+    fill: #CBD5E1;
+  }
+  .label-bg {
+    fill: #F3F4F6;
+    stroke: white;
+    stroke-width: 2px;
+    filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.1));
+  }
+  .link-label {
+    fill: #475569;
+    font-size: 12px;
+    text-anchor: middle;
+    pointer-events: none;
+  }
+  .legend-item {
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    color: white;
+    margin-right: 4px;
+    margin-bottom: 4px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  }
+  .legend-item.disabled {
+    opacity: 0.5;
+  }
 </style>
 
 <!-- 
@@ -69,7 +118,7 @@ letting the user enter a name, see results, and click to load GraphViz mode.
   <form id="searchForm" class="flex flex-wrap gap-2 items-end">
     <div>
       <label for="searchBox" class="text-sm font-bold mb-1">Name/Keyword(s)</label><br/>
-      <input type="text" id="searchBox" class="border border-gray-200 rounded p-2 w-full" placeholder="E.g. ‘aaron’ or ‘14th Dalai Lama’"/>
+      <input type="text" id="searchBox" class="border border-gray-200 rounded p-2 w-full" placeholder="E.g. 'aaron' or '14th Dalai Lama'"/>
     </div>
 
     <button type="submit" id="searchButton" class="p-2 border border-gray-200 rounded font-bold text-sm">
@@ -105,9 +154,9 @@ It shows the generated graph and a legend, plus a button to go back to the searc
 <div id="graphExplanation" class="mb-3">
   <h1 id="graphTitle" class="mb-1">Relationship Graph</h1>
   <p class="text-sm mb-2" id="graphInstructions">
-    Below is a visualization of our selected subject’s relationships, color-coded by category.  
+    Below is a visualization of our selected subject's relationships, color-coded by category.  
     <strong>Click any color</strong> in the legend below to toggle that category on/off. The graph will re-render automatically.  
-    Click “Download SVG” to get an offline copy of the image.
+    Click "Download SVG" to get an offline copy of the image.
   </p>
 </div>
 
@@ -119,7 +168,17 @@ It shows the generated graph and a legend, plus a button to go back to the searc
 
 <!-- Where the graph renders -->
 <div id="graph-container" class="border rounded flex items-center justify-center bg-white">
-  <div>
+  <svg id="graph" width="100%" height="100%">
+    <!-- Arrow marker definition for edges -->
+    <defs>
+      <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
+        markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-path" />
+      </marker>
+    </defs>
+    <g id="graph-content"></g>
+  </svg>
+  <div id="loading-indicator" class="absolute">
     <img src="../assets/images/loading.svg" class="loading-spinner" style="width:32px;height:32px" alt="Loading...">
   </div>
 </div>
@@ -157,13 +216,31 @@ let categoryColors = {
   "UNKNOWN": "#6B7280"
 };
 
-let panZoomInstance = null;
+// D3 Graph variables
+let width, height;
+let simulation = null;
+let zoom = null;
+let nodeElements = null;
+let linkElements = null;
+let labelElements = null;
 
 // We store all graph edges in memory so toggling categories is easy:
 let globalNodesMap = new Map();  // subject -> bullet info
 let globalAllEdges = [];         // all edges (including duplicates filtered out)
 let globalActiveCategories = new Set(); // which categories are currently on display
 
+// Force simulation parameters
+const forceParams = {
+  linkDistance: 400,
+  charge: -3000,
+  collisionRadius: 200,
+  bounds: {
+    left: 100,
+    right: 100,
+    top: 100,
+    bottom: 100
+  }
+};
 
 /***************************************
 * ON LOAD
@@ -470,10 +547,9 @@ $('#backToSearch').on('click', function() {
 * GRAPH MODE
 ***************************************/
 async function renderGraphForSubject(subjectName) {
-  // Show spinner in #graph-container
-  $('#graph-container').html(`
-    <div><img src="../assets/images/loading.svg" style="width:32px;height:32px" alt="Loading..."></div>
-  `);
+  // Show loading indicator
+  $('#loading-indicator').show();
+  $('#graph-content').empty();
 
   // Set the search param in the URL
   const newUrl = new URL(window.location);
@@ -500,6 +576,9 @@ async function renderGraphForSubject(subjectName) {
   globalAllEdges = [];
   globalActiveCategories.clear();
 
+  // Initialize D3 graph
+  initializeD3Graph();
+
   // Add the root node
   addNodeIfNeeded(globalNodesMap, subjectName);
 
@@ -509,12 +588,28 @@ async function renderGraphForSubject(subjectName) {
   const relationsZip = `relations_${pStr}.zip`;
 
   try {
+    // Show loading status
+    $('#graphInstructions').html(`
+      <div class="flex items-center gap-2">
+        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
+        <span>Loading relationship data for ${escapeHtml(subjectName)}...</span>
+      </div>
+    `);
+
     const resp = await fetch(relationsZip);
     if (!resp.ok) {
       throw new Error(`Unable to fetch ${relationsZip}`);
     }
     const buffer = await resp.arrayBuffer();
     const z = await JSZip.loadAsync(buffer);
+
+    // Update loading status
+    $('#graphInstructions').html(`
+      <div class="flex items-center gap-2">
+        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
+        <span>Parsing relationship data...</span>
+      </div>
+    `);
 
     // parse relations.csv, relations_reverse.csv, intergraph_edges.csv
     const relationsCsv     = await getZipText(z, 'relations.csv');
@@ -524,6 +619,14 @@ async function renderGraphForSubject(subjectName) {
     const parsedRelations  = Papa.parse(relationsCsv,     { header:true, skipEmptyLines:true }).data;
     const parsedReverse    = Papa.parse(revCsv,           { header:true, skipEmptyLines:true }).data;
     const parsedIntergraph = Papa.parse(interCsv,         { header:true, skipEmptyLines:true }).data;
+
+    // Update loading status
+    $('#graphInstructions').html(`
+      <div class="flex items-center gap-2">
+        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
+        <span>Building relationship graph...</span>
+      </div>
+    `);
 
     let edgesSet = new Set(); // to ensure no duplicates
 
@@ -610,23 +713,63 @@ async function renderGraphForSubject(subjectName) {
     // Render the legend
     renderLegend([...uniqueCats]);
 
-    // Build and render final
-    reRenderGraph(subjectName);
+    // Update loading status
+    $('#graphInstructions').html(`
+      <div class="flex items-center gap-2">
+        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
+        <span>Rendering graph with ${globalNodesMap.size} nodes and ${globalAllEdges.length} connections...</span>
+      </div>
+    `);
+
+    // Prepare data for D3
+    const nodes = [];
+    const edges = [];
+    
+    // Add nodes
+    for (let [subject, bulletInfo] of globalNodesMap.entries()) {
+      nodes.push({
+        id: subject,
+        bulletInfo: bulletInfo
+      });
+    }
+    
+    // Add edges
+    for (let edge of globalAllEdges) {
+      edges.push({
+        source: edge.from,
+        target: edge.to,
+        from: edge.from,
+        to: edge.to,
+        label: edge.label,
+        category: edge.category,
+        color: edge.color
+      });
+    }
+    
+    // Render the D3 graph
+    renderD3Graph(subjectName, nodes, edges);
+
+    // Restore instructions
+    setTimeout(() => {
+      $('#graphInstructions').html(`
+        Below is a visualization of our selected subject's relationships, color-coded by category.  
+        <strong>Click any color</strong> in the legend below to toggle that category on/off. The graph will re-render automatically.  
+        Click "Download SVG" to get an offline copy of the image.
+      `);
+    }, 1000);
 
   } catch (err) {
     console.error(err);
     $('#graph-container').html(
       `<div class="p-2 text-center text-sm text-red-500">Error loading relationships: ${err}</div>`
     );
+    $('#graphInstructions').html(`
+      <div class="text-red-500">Error: ${escapeHtml(err.message)}</div>
+    `);
   }
 }
 
 // Build & render the DOT from globalNodesMap + filtered edges
-function reRenderGraph(rootSubject) {
-  let activeEdges = globalAllEdges.filter(e => globalActiveCategories.has(e.category));
-  let dotSrc = buildDotSource(rootSubject, globalNodesMap, activeEdges);
-  renderDot(dotSrc);
-}
 
 // A function to ensure node exists
 function addNodeIfNeeded(map, subject) {
@@ -659,28 +802,6 @@ async function getZipText(zipObj, filename) {
 
 
 /***************************************
-* DOT BUILDING / RENDERING
-***************************************/
-// We insert <br> every ~50 chars on word boundaries
-function insertLineBreaks(str, maxLen=50) {
-  if (!str) return '';
-  const words = str.split(/\s+/);
-  let lines = [];
-  let current = '';
-
-  for (let w of words) {
-    if (!current) {
-      current = w;
-    } else if ((current + ' ' + w).length > maxLen) {
-      lines.push(escapeHtml(current));
-      current = w;
-    } else {
-      current += ' ' + w;
-    }
-  }
-  if (current) lines.push(escapeHtml(current));
-  return lines.join("<BR/>");
-}
 
 function buildDotSource(rootSubject, nodesMap, edges) {
   let dot = `digraph G {
@@ -761,8 +882,8 @@ function renderLegend(categories) {
   let html = '';
   categories.sort(); // optional: sort them alphabetically
   for (let c of categories) {
-    let colorClass = 'legend-' + c;
-    html += `<div class="legend-item ${colorClass}" data-cat="${c}">${c}</div>`;
+    let color = categoryColors[c] || categoryColors["UNKNOWN"];
+    html += `<div class="legend-item" data-cat="${c}" style="background-color: ${color};">${c}</div>`;
   }
   $('#legend').html(html);
 
@@ -781,9 +902,19 @@ function toggleCategory(cat) {
   } else {
     globalActiveCategories.add(cat);
   }
-  // re-render
-  let rootName = $('#graphTitle').text().trim();
-  reRenderGraph(rootName);
+  
+  // Filter edges based on active categories
+  const activeEdges = globalAllEdges.filter(e => globalActiveCategories.has(e.category));
+  
+  // Update edge visibility
+  linkElements.attr('visibility', d => 
+    globalActiveCategories.has(d.category) ? 'visible' : 'hidden'
+  );
+  
+  // Update label visibility
+  labelElements.attr('visibility', d => 
+    globalActiveCategories.has(d.category) ? 'visible' : 'hidden'
+  );
 }
 
 
@@ -791,14 +922,29 @@ function toggleCategory(cat) {
 * DOWNLOAD SVG
 ***************************************/
 $('#downloadBtn').on('click', function() {
-  let svgEl = document.querySelector('#graph-container svg');
+  const svgEl = document.querySelector('#graph');
   if (!svgEl) {
     alert('No SVG to download');
     return;
   }
-  let svgData = new XMLSerializer().serializeToString(svgEl);
-  let blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
-  let url = URL.createObjectURL(blob);
+  
+  // Create a clone of the SVG to modify for download
+  const clonedSvg = svgEl.cloneNode(true);
+  
+  // Set explicit width and height
+  clonedSvg.setAttribute('width', width);
+  clonedSvg.setAttribute('height', height);
+  
+  // Reset the transform to ensure the graph is centered
+  const content = clonedSvg.querySelector('#graph-content');
+  if (content) {
+    content.setAttribute('transform', `translate(${width/2}, ${height/2})`);
+  }
+  
+  // Convert to string
+  const svgData = new XMLSerializer().serializeToString(clonedSvg);
+  const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
 
   let link = document.createElement('a');
   link.href = url;
@@ -820,5 +966,533 @@ function escapeHtml(str) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
+}
+
+/***************************************
+* D3 GRAPH RENDERING
+***************************************/
+function initializeD3Graph() {
+  // Get container dimensions
+  const container = document.getElementById('graph-container');
+  width = container.clientWidth;
+  height = container.clientHeight;
+  
+  // Initialize zoom behavior
+  zoom = d3.zoom()
+    .scaleExtent([0.1, 2])
+    .on('zoom', (event) => {
+      d3.select('#graph-content').attr('transform', event.transform);
+    });
+  
+  // Apply zoom behavior to SVG
+  d3.select('#graph')
+    .call(zoom)
+    .on('dblclick.zoom', null); // Disable double-click zoom
+    
+  // Reset zoom and pan
+  resetZoom();
+  
+  // Show loading indicator
+  $('#loading-indicator').show();
+}
+
+function resetZoom() {
+  d3.select('#graph').call(
+    zoom.transform,
+    d3.zoomIdentity.translate(width/2, height/2)
+  );
+}
+
+function renderD3Graph(rootSubject, nodes, edges) {
+  // Clear previous graph
+  d3.select('#graph-content').selectAll('*').remove();
+  
+  // Hide loading indicator when rendering starts
+  $('#loading-indicator').hide();
+  
+  // Create the graph content group
+  const g = d3.select('#graph-content');
+  
+  // Create links
+  linkElements = g.append('g')
+    .attr('class', 'links')
+    .selectAll('path')
+    .data(edges)
+    .join('path')
+    .attr('class', 'link')
+    .attr('stroke', d => d.color)
+    .attr('stroke-width', 2)
+    .attr('marker-end', 'url(#arrow)');
+  
+  // Create nodes
+  nodeElements = g.append('g')
+    .attr('class', 'nodes')
+    .selectAll('g')
+    .data(nodes)
+    .join('g')
+    .attr('class', d => d.id === rootSubject ? 'node root' : 'node')
+    .attr('data-id', d => d.id)
+    .call(d3.drag()
+      .on('start', dragStarted)
+      .on('drag', dragged)
+      .on('end', dragEnded)
+    );
+  
+  // Add rectangles to nodes
+  nodeElements.append('rect')
+    .attr('rx', 4)
+    .attr('ry', 4)
+    .attr('width', d => getNodeWidth(d))
+    .attr('height', d => getNodeHeight(d))
+    .style('cursor', 'grab');
+  
+  // Add text to nodes
+  nodeElements.each(function(d) {
+    const node = d3.select(this);
+    const bulletInfo = d.bulletInfo;
+    const padding = 10;
+    let y = padding;
+    
+    // Add subject name
+    node.append('text')
+      .attr('x', padding)
+      .attr('y', y + 15)
+      .attr('font-weight', 'bold')
+      .attr('font-size', '14px')
+      .text(d.id);
+    y += 25;
+    
+    // Add bullet point 1 if available
+    if (bulletInfo.bullet_point1) {
+      const wrappedText = wrapText(bulletInfo.bullet_point1, 30);
+      wrappedText.forEach(line => {
+        node.append('text')
+          .attr('x', padding)
+          .attr('y', y + 12)
+          .attr('font-size', '12px')
+          .text(line);
+        y += 18;
+      });
+    }
+    
+    // Add bullet point 2 if available
+    if (bulletInfo.bullet_point2) {
+      y += 5; // Add a little extra space
+      const wrappedText = wrapText(bulletInfo.bullet_point2, 30);
+      wrappedText.forEach(line => {
+        node.append('text')
+          .attr('x', padding)
+          .attr('y', y + 12)
+          .attr('font-size', '12px')
+          .text(line);
+        y += 18;
+      });
+    }
+  });
+  
+  // Create edge labels
+  const labelGroup = g.append('g').attr('class', 'label-group');
+  labelElements = labelGroup.selectAll('g')
+    .data(edges)
+    .join('g')
+    .attr('class', 'link-label-group');
+  
+  // Add background pill for labels
+  labelElements.append('rect')
+    .attr('rx', 12)
+    .attr('ry', 12)
+    .attr('class', 'label-bg')
+    .style('cursor', 'pointer')
+    .on('mouseover', function(event, d) {
+      d3.select(this).attr('fill', d.color);
+      d3.select(this.parentNode).select('.link-label').attr('fill', 'white');
+      linkElements.filter(l => l === d).attr('stroke-width', 4);
+    })
+    .on('mouseout', function() {
+      d3.select(this).attr('fill', '#F3F4F6');
+      d3.select(this.parentNode).select('.link-label').attr('fill', '#475569');
+      linkElements.attr('stroke-width', 2);
+    });
+  
+  // Add text labels with wrapping
+  labelElements.each(function(d) {
+    const labelGroup = d3.select(this);
+    const label = d.label || "";
+    
+    // Skip empty labels
+    if (!label.trim()) {
+      labelGroup.append('text')
+        .attr('class', 'link-label')
+        .text("");
+      return;
+    }
+    
+    // Wrap text to max 20 characters per line
+    const wrappedText = wrapText(label, 20);
+    
+    // Add each line of text
+    wrappedText.forEach((line, i) => {
+      labelGroup.append('text')
+        .attr('class', 'link-label')
+        .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
+        .text(line);
+    });
+  });
+  
+  // Add hover effects to nodes
+  nodeElements.on('mouseover', function(event, d) {
+    // Highlight this node
+    d3.select(this).select('rect')
+      .attr('stroke-width', 3)
+      .attr('stroke', '#2563EB');
+    
+    // Highlight connected edges and nodes
+    linkElements.each(function(link) {
+      if (link.from === d.id || link.to === d.id) {
+        d3.select(this)
+          .attr('stroke-width', 4)
+          .attr('stroke', link.color);
+        
+        // Highlight connected node
+        const connectedId = link.from === d.id ? link.to : link.from;
+        nodeElements.filter(n => n.id === connectedId)
+          .select('rect')
+          .attr('stroke-width', 2)
+          .attr('stroke', link.color);
+      }
+    });
+    
+    // Highlight related labels
+    labelElements.each(function(label) {
+      if (label.from === d.id || label.to === d.id) {
+        d3.select(this).select('.label-bg')
+          .attr('fill', label.color);
+        d3.select(this).select('.link-label')
+          .attr('fill', 'white');
+      }
+    });
+  })
+  .on('mouseout', function() {
+    // Reset node styles
+    nodeElements.select('rect')
+      .attr('stroke-width', d => d.id === rootSubject ? 3 : 1)
+      .attr('stroke', d => d.id === rootSubject ? '#2563EB' : '#94A3B8');
+    
+    // Reset edge styles
+    linkElements
+      .attr('stroke-width', 2)
+      .attr('stroke', d => d.color);
+    
+    // Reset label styles
+    labelElements.select('.label-bg')
+      .attr('fill', '#F3F4F6');
+    labelElements.select('.link-label')
+      .attr('fill', '#475569');
+  });
+  
+  // Start the simulation
+  simulation = d3.forceSimulation(nodes)
+    .force('link', d3.forceLink(edges)
+      .id(d => d.id)
+      .distance(d => {
+        // Adjust link distance based on node sizes
+        const sourceNode = nodes.find(n => n.id === d.from);
+        const targetNode = nodes.find(n => n.id === d.to);
+        if (!sourceNode || !targetNode) return forceParams.linkDistance;
+        
+        const sourceSize = Math.sqrt(getNodeWidth(sourceNode) * getNodeHeight(sourceNode));
+        const targetSize = Math.sqrt(getNodeWidth(targetNode) * getNodeHeight(targetNode));
+        
+        // Base distance on node sizes plus padding
+        return (sourceSize + targetSize) / 2 + forceParams.linkDistance;
+      }))
+    .force('charge', d3.forceManyBody()
+      .strength(d => {
+        // Adjust repulsion based on node size
+        const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
+        return forceParams.charge * (nodeSize / 200);
+      })
+      .distanceMin(150)
+      .distanceMax(2000))
+    .force('center', d3.forceCenter(width / 2, height / 2))
+    .force('x', d3.forceX(width / 2).strength(0.05))
+    .force('y', d3.forceY(height / 2).strength(0.05))
+    .force('collision', d3.forceCollide().radius(d => {
+      // Make collision radius based on node size plus padding
+      const nodeWidth = getNodeWidth(d);
+      const nodeHeight = getNodeHeight(d);
+      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 50;
+    }).strength(1))
+    .alpha(0.6)
+    .alphaDecay(0.01) // Slower decay for more time to find optimal positions
+    .velocityDecay(0.4) // Lower value to allow nodes to move more freely
+    .on('tick', ticked);
+  
+  // Enable download button
+  $('#downloadBtn').show();
+  
+  // Auto-zoom to fit all nodes after simulation stabilizes
+  setTimeout(() => {
+    zoomToFitAll();
+  }, 2000);
+}
+
+// Function to zoom to fit all nodes
+function zoomToFitAll() {
+  if (!nodeElements || !nodeElements.size()) return;
+  
+  // Get bounding box of all nodes
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  
+  nodeElements.each(function(d) {
+    const nodeWidth = getNodeWidth(d);
+    const nodeHeight = getNodeHeight(d);
+    
+    minX = Math.min(minX, d.x - nodeWidth/2);
+    minY = Math.min(minY, d.y - nodeHeight/2);
+    maxX = Math.max(maxX, d.x + nodeWidth/2);
+    maxY = Math.max(maxY, d.y + nodeHeight/2);
+  });
+  
+  // Add padding
+  const padding = 50;
+  minX -= padding;
+  minY -= padding;
+  maxX += padding;
+  maxY += padding;
+  
+  const graphWidth = maxX - minX;
+  const graphHeight = maxY - minY;
+  
+  // Calculate scale to fit
+  const scale = Math.min(
+    width / graphWidth,
+    height / graphHeight,
+    1.5 // Max scale
+  );
+  
+  // Calculate center point
+  const centerX = minX + graphWidth/2;
+  const centerY = minY + graphHeight/2;
+  
+  // Apply zoom transform
+  d3.select('#graph').transition()
+    .duration(750)
+    .call(
+      zoom.transform,
+      d3.zoomIdentity
+        .translate(width/2, height/2)
+        .scale(scale)
+        .translate(-centerX, -centerY)
+    );
+}
+
+function ticked() {
+  // Update node positions
+  nodeElements.attr('transform', d => {
+    // Constrain to bounds
+    d.x = Math.max(forceParams.bounds.left, Math.min(width - forceParams.bounds.right, d.x));
+    d.y = Math.max(forceParams.bounds.top, Math.min(height - forceParams.bounds.bottom, d.y));
+    return `translate(${d.x - getNodeWidth(d) / 2}, ${d.y - getNodeHeight(d) / 2})`;
+  });
+  
+  // Update link paths
+  linkElements.attr('d', d => {
+    const sourceNode = nodeElements.filter(n => n.id === d.from).datum();
+    const targetNode = nodeElements.filter(n => n.id === d.to).datum();
+    
+    if (!sourceNode || !targetNode) return '';
+    
+    const sourceWidth = getNodeWidth(sourceNode);
+    const sourceHeight = getNodeHeight(sourceNode);
+    const targetWidth = getNodeWidth(targetNode);
+    const targetHeight = getNodeHeight(targetNode);
+    
+    // Calculate source and target points on the edges of the rectangles
+    const sourceX = sourceNode.x;
+    const sourceY = sourceNode.y;
+    const targetX = targetNode.x;
+    const targetY = targetNode.y;
+    
+    // Find intersection points with rectangles
+    const sourcePoint = findIntersectionPoint(
+      sourceX, sourceY, targetX, targetY,
+      sourceX - sourceWidth/2, sourceY - sourceHeight/2,
+      sourceWidth, sourceHeight
+    );
+    
+    const targetPoint = findIntersectionPoint(
+      targetX, targetY, sourceX, sourceY,
+      targetX - targetWidth/2, targetY - targetHeight/2,
+      targetWidth, targetHeight
+    );
+    
+    if (!sourcePoint || !targetPoint) return '';
+    
+    // Add a slight curve to the path to make overlapping paths more visible
+    const dx = targetPoint.x - sourcePoint.x;
+    const dy = targetPoint.y - sourcePoint.y;
+    const dr = Math.sqrt(dx * dx + dy * dy) * 1.2;
+    
+    // Use curved paths for better visibility when there are multiple edges
+    return `M${sourcePoint.x},${sourcePoint.y} A${dr},${dr} 0 0,1 ${targetPoint.x},${targetPoint.y}`;
+  });
+  
+  // Update label positions
+  labelElements.attr('transform', d => {
+    const path = linkElements.filter(l => l === d).node();
+    if (!path) return '';
+    
+    const pathLength = path.getTotalLength();
+    if (isNaN(pathLength) || pathLength === 0) return '';
+    
+    // Position label at the midpoint of the path
+    const midPoint = path.getPointAtLength(pathLength / 2);
+    return `translate(${midPoint.x}, ${midPoint.y})`;
+  });
+  
+  // Update label background sizes
+  labelElements.each(function(d) {
+    const labelTexts = d3.select(this).selectAll('.link-label');
+    if (!labelTexts.size()) return;
+    
+    // Calculate bounding box that encompasses all text elements
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    
+    labelTexts.each(function() {
+      const bbox = this.getBBox();
+      minX = Math.min(minX, bbox.x);
+      minY = Math.min(minY, bbox.y);
+      maxX = Math.max(maxX, bbox.x + bbox.width);
+      maxY = Math.max(maxY, bbox.y + bbox.height);
+    });
+    
+    // Add padding
+    const padding = { x: 10, y: 6 };
+    
+    d3.select(this).select('.label-bg')
+      .attr('x', minX - padding.x)
+      .attr('y', minY - padding.y)
+      .attr('width', maxX - minX + padding.x * 2)
+      .attr('height', maxY - minY + padding.y * 2);
+  });
+}
+
+function dragStarted(event, d) {
+  if (!event.active) simulation.alphaTarget(0.3).restart();
+  d.fx = d.x;
+  d.fy = d.y;
+  d3.select(this).style('cursor', 'grabbing');
+}
+
+function dragged(event, d) {
+  d.fx = event.x;
+  d.fy = event.y;
+}
+
+function dragEnded(event, d) {
+  if (!event.active) simulation.alphaTarget(0);
+  d.fx = null;
+  d.fy = null;
+  d3.select(this).style('cursor', 'grab');
+}
+
+function getNodeWidth(d) {
+  // Calculate width based on text content
+  const minWidth = 200;
+  const textLength = d.id.length;
+  const bulletLength1 = d.bulletInfo?.bullet_point1?.length || 0;
+  const bulletLength2 = d.bulletInfo?.bullet_point2?.length || 0;
+  const maxTextLength = Math.max(textLength, bulletLength1 / 5, bulletLength2 / 5);
+  return Math.max(minWidth, maxTextLength * 7);
+}
+
+function getNodeHeight(d) {
+  // Calculate height based on text content
+  const baseHeight = 50; // Minimum height
+  const bulletInfo = d.bulletInfo;
+  let additionalHeight = 0;
+  
+  if (bulletInfo.bullet_point1) {
+    const lines1 = Math.ceil(bulletInfo.bullet_point1.length / 30);
+    additionalHeight += lines1 * 18;
+  }
+  
+  if (bulletInfo.bullet_point2) {
+    const lines2 = Math.ceil(bulletInfo.bullet_point2.length / 30);
+    additionalHeight += lines2 * 18 + 5; // +5 for spacing
+  }
+  
+  return baseHeight + additionalHeight;
+}
+
+function wrapText(text, maxCharsPerLine) {
+  if (!text) return [];
+  
+  const words = text.split(' ');
+  const lines = [];
+  let currentLine = '';
+  
+  words.forEach(word => {
+    const testLine = currentLine ? `${currentLine} ${word}` : word;
+    if (testLine.length <= maxCharsPerLine) {
+      currentLine = testLine;
+    } else {
+      lines.push(currentLine);
+      currentLine = word;
+    }
+  });
+  
+  if (currentLine) {
+    lines.push(currentLine);
+  }
+  
+  return lines;
+}
+
+function findIntersectionPoint(x1, y1, x2, y2, rectX, rectY, rectWidth, rectHeight) {
+  // Calculate rectangle corners
+  const corners = [
+    { x: rectX, y: rectY }, // top-left
+    { x: rectX + rectWidth, y: rectY }, // top-right
+    { x: rectX + rectWidth, y: rectY + rectHeight }, // bottom-right
+    { x: rectX, y: rectY + rectHeight } // bottom-left
+  ];
+  
+  // Check intersection with each edge of the rectangle
+  const edges = [
+    [corners[0], corners[1]], // top
+    [corners[1], corners[2]], // right
+    [corners[2], corners[3]], // bottom
+    [corners[3], corners[0]]  // left
+  ];
+  
+  for (const [p1, p2] of edges) {
+    const intersection = lineIntersection(x1, y1, x2, y2, p1.x, p1.y, p2.x, p2.y);
+    if (intersection) {
+      return intersection;
+    }
+  }
+  
+  // If no intersection found, return center of rectangle
+  return { x: rectX + rectWidth / 2, y: rectY + rectHeight / 2 };
+}
+
+function lineIntersection(x1, y1, x2, y2, x3, y3, x4, y4) {
+  // Calculate determinants
+  const den = (y4 - y3) * (x2 - x1) - (x4 - x3) * (y2 - y1);
+  if (den === 0) return null; // Lines are parallel
+  
+  const ua = ((x4 - x3) * (y1 - y3) - (y4 - y3) * (x1 - x3)) / den;
+  const ub = ((x2 - x1) * (y1 - y3) - (y2 - y1) * (x1 - x3)) / den;
+  
+  // Check if intersection is on both line segments
+  if (ua < 0 || ua > 1 || ub < 0 || ub > 1) return null;
+  
+  // Calculate intersection point
+  const x = x1 + ua * (x2 - x1);
+  const y = y1 + ua * (y2 - y1);
+  
+  return { x, y };
 }
 </script>

--- a/relations/index.html
+++ b/relations/index.html
@@ -326,9 +326,9 @@ let globalActiveCategories = new Set(); // which categories are currently on dis
 
 // Force simulation parameters
 const forceParams = {
-  linkDistance: 1200,     // Doubled from 600
-  charge: -10000,         // Doubled from -5000
-  collisionRadius: 500,   // Increased from 300
+  linkDistance: 800,     // Reduced from 1200
+  charge: -8000,         // Reduced from -10000
+  collisionRadius: 400,   // Reduced from 500
   bounds: {
     left: 300,
     right: 300,
@@ -1743,7 +1743,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .stop();
   
   // Run the pre-positioning simulation for more iterations
-  for (let i = 0; i < 150; i++) {
+  for (let i = 0; i < 50; i++) {  // Reduced from 150 to 50 iterations
     tempSimulation.tick();
   }
   
@@ -1755,59 +1755,59 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .distance(d => {
         // Use different distances for different types of connections
         if (d.from === rootSubject || d.to === rootSubject) {
-          return forceParams.linkDistance * 10; // More space for root connections
+          return forceParams.linkDistance * 8; // Reduced from 10
         }
-        return forceParams.linkDistance * 7; // More space for non-root connections
+        return forceParams.linkDistance * 5; // Reduced from 7
       }))
     .force('charge', d3.forceManyBody()
       .strength(d => {
         // Use stronger repulsion for the root
         if (d.id === rootSubject) {
-          return forceParams.charge * -20;
+          return forceParams.charge * -15; // Reduced from -20
         }
         // Use node size to scale repulsion
         const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
-        return forceParams.charge * (nodeSize / 150) * -15;
+        return forceParams.charge * (nodeSize / 150) * -10; // Reduced from -15
       })
-      .distanceMin(900)
-      .distanceMax(12000))
+      .distanceMin(600) // Reduced from 900
+      .distanceMax(8000)) // Reduced from 12000
     .force('x', d3.forceX(d => {
       // Root node stays at center
       if (d.id === rootSubject) return 0;
       
       // First level nodes maintain their existing x position but with scaling
       if (firstLevelNodeIds.has(d.id)) {
-        return d.x * 1.3; // Expand the first level more
+        return d.x * 1.2; // Reduced from 1.3
       }
       
       // Second level nodes spread wider
-      return d.x * 1.4;
-    }).strength(d => d.id === rootSubject ? 1 : 0.2))
+      return d.x * 1.3; // Reduced from 1.4
+    }).strength(d => d.id === rootSubject ? 1 : 0.3)) // Increased from 0.2 for faster positioning
     .force('y', d3.forceY(d => {
       // Keep root at top
-      if (d.id === rootSubject) return -height * 0.4;
+      if (d.id === rootSubject) return -height * 0.3; // Reduced from 0.4
       
       // First level nodes position
       if (firstLevelNodeIds.has(d.id)) {
-        return d.y * 0.95; // Keep in their semi-circle but slightly tighter
+        return d.y * 0.9; // Adjust as needed
       }
       
       // Second level nodes position
-      return d.y * 1.3; // Push further down
-    }).strength(d => d.id === rootSubject ? 1 : 0.35))
+      return d.y * 1.2; // Reduced from 1.3
+    }).strength(d => d.id === rootSubject ? 1 : 0.4)) // Increased from 0.35
     .force('collision', d3.forceCollide().radius(d => {
       // Use much larger collision radius
       const nodeWidth = getNodeWidth(d);
       const nodeHeight = getNodeHeight(d);
       // Different collision radii based on node type
       if (d.id === rootSubject) {
-        return Math.sqrt(nodeWidth * nodeHeight) + 180;
+        return Math.sqrt(nodeWidth * nodeHeight) + 150; // Reduced from 180
       }
-      return Math.sqrt(nodeWidth * nodeHeight) + 130;
-    }).strength(0.95).iterations(4)) // More iterations for better collision resolution
-    .alpha(0.4) // Start with lower alpha since we've pre-positioned
-    .alphaDecay(0.003) // Slower decay for more gradual layout
-    .velocityDecay(0.25) // Adjust velocity decay for smoother movement
+      return Math.sqrt(nodeWidth * nodeHeight) + 100; // Reduced from 130
+    }).strength(0.8).iterations(2)) // Reduced iterations from 4 to 2
+    .alpha(0.5) // Slightly higher alpha for faster convergence
+    .alphaDecay(0.015) // Increased from 0.003 for faster convergence
+    .velocityDecay(0.3) // Increased from 0.25 for slightly more damping
     .on('tick', ticked)
     .on('end', () => {
       // When the simulation ends, center the graph based on actual content bounds

--- a/relations/index.html
+++ b/relations/index.html
@@ -2474,11 +2474,13 @@ function preventLabelOverlaps() {
     // First collect all node rectangles for overlap checking
     const nodeRects = [];
     nodeElements.each(function(d) {
+      // Add extra padding around nodes
+      const extraPadding = 40;
       nodeRects.push({
-        x: d.x - getNodeWidth(d) / 2,
-        y: d.y - getNodeHeight(d) / 2,
-        width: getNodeWidth(d),
-        height: getNodeHeight(d),
+        x: d.x - getNodeWidth(d) / 2 - extraPadding,
+        y: d.y - getNodeHeight(d) / 2 - extraPadding,
+        width: getNodeWidth(d) + extraPadding * 2,
+        height: getNodeHeight(d) + extraPadding * 2,
         id: d.id,
         type: 'node',
         center: { x: d.x, y: d.y }
@@ -2525,16 +2527,15 @@ function preventLabelOverlaps() {
     });
     
     // Process each label to avoid overlaps
-    for (let i = 0; i < labelRects.length; i++) {
-      const labelRect = labelRects[i];
+    for (const labelRect of labelRects) {
       let hasOverlap = true;
       let attempts = 0;
-      const maxAttempts = 10; // Limit repositioning attempts
+      const maxAttempts = 12; // Increased from default
       
-      // Try to find a position without overlaps
       while (hasOverlap && attempts < maxAttempts) {
         hasOverlap = false;
         attempts++;
+        
         
         // Check for overlaps with nodes
         for (const nodeRect of nodeRects) {
@@ -2570,11 +2571,14 @@ function preventLabelOverlaps() {
             const midX = (sourceCenter.x + targetCenter.x) / 2;
             const midY = (sourceCenter.y + targetCenter.y) / 2;
             
-            // Calculate distance to place label
-            const distance = Math.max(labelRect.width, labelRect.height) * 1.5;
+            // Calculate distance to place label - increased for more spacing
+            const baseDistance = Math.max(labelRect.width, labelRect.height) * 2;
+            const distance = baseDistance + (attempts * 20); // Gradually increase distance with each attempt
             
-            // Try different angles
-            const angle = (Math.PI * 2 * attempts) / maxAttempts;
+            // Try different angles with slight randomization
+            const angleStep = (Math.PI * 2) / maxAttempts;
+            const angle = angleStep * attempts + (Math.random() * 0.2 - 0.1);
+            
             labelRect.x = midX + Math.cos(angle) * distance - labelRect.width / 2;
             labelRect.y = midY + Math.sin(angle) * distance - labelRect.height / 2;
           }
@@ -2598,8 +2602,8 @@ function preventLabelOverlaps() {
 
 // Helper function to check if two rectangles overlap
 function rectsOverlap(rect1, rect2) {
-  // Add a buffer zone to ensure labels don't touch
-  const buffer = 25; // Increased buffer
+  // Add a larger buffer zone to ensure labels don't touch
+  const buffer = 35; // Increased from 25
   
   return !(
     rect1.x + rect1.width + buffer < rect2.x ||

--- a/relations/index.html
+++ b/relations/index.html
@@ -1475,10 +1475,20 @@ function renderD3Graph(rootSubject, nodes, edges) {
       
       // Highlight this connection
       highlightConnection(d.from, d.to);
+      
+      // Highlight the specific path
+      linkElements.filter(l => l.from === d.from && l.to === d.to)
+        .attr('stroke-width', 4)
+        .attr('stroke-opacity', 1);
     })
-    .on('mouseout', function() {
+    .on('mouseout', function(event, d) {
       console.log('Label bg mouseout');
       resetHighlights();
+      
+      // Restore original path styling
+      linkElements.filter(l => l.from === d.from && l.to === d.to)
+        .attr('stroke-width', 2)
+        .attr('stroke-opacity', 0.8);
     });
     
   // Add text labels with wrapping
@@ -1496,18 +1506,34 @@ function renderD3Graph(rootSubject, nodes, edges) {
         return;
       }
       
-      // Wrap text to max 20 characters per line
-      const wrappedText = wrapText(label, 20);
+      // For "Son of" relationship, use special styling and don't wrap
+      const isSonOfRelation = label.includes("Son of") || label.includes("Child of") || 
+                             label.includes("Parent of") || label.includes("Father of") || 
+                             label.includes("Mother of");
       
-      // Add each line of text
-      wrappedText.forEach((line, i) => {
+      if (isSonOfRelation) {
+        // Use a single text element with special styling for these important relationships
         labelGroup.append('text')
-          .attr('class', 'link-label')
-          .attr('fill', '#475569')
-          .attr('text-anchor', 'middle') // Center text
-          .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
-          .text(line);
-      });
+          .attr('class', 'link-label relationship-label')
+          .attr('fill', '#3B82F6') // Blue color for relationship labels
+          .attr('text-anchor', 'middle')
+          .attr('font-weight', 'bold')
+          .attr('dy', '0.3em')
+          .text(label);
+      } else {
+        // Wrap text to max 20 characters per line for other relationships
+        const wrappedText = wrapText(label, 20);
+        
+        // Add each line of text
+        wrappedText.forEach((line, i) => {
+          labelGroup.append('text')
+            .attr('class', 'link-label')
+            .attr('fill', '#475569')
+            .attr('text-anchor', 'middle') // Center text
+            .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
+            .text(line);
+        });
+      }
       
       if (!d.pathPoints) {
         return;
@@ -1605,15 +1631,14 @@ function renderD3Graph(rootSubject, nodes, edges) {
           .attr('height', labelHeight)
           .attr('x', -labelWidth / 2)
           .attr('y', -labelHeight / 2);
+        
+        // Update the text position to match the background
+        labelEl.attr('transform', `translate(${labelX},${labelY})`);
+        
+        // Store the position for use in interactions
+        d.labelX = labelX;
+        d.labelY = labelY;
       }
-      
-      // Apply the transform to position the label
-      labelEl.attr('transform', `translate(${labelX}, ${labelY})`);
-      
-      // Store position for collision detection
-      d.labelX = labelX;
-      d.labelY = labelY;
-      
     } catch (error) {
       console.error("Error positioning label:", error);
     }
@@ -2095,6 +2120,9 @@ function ticked() {
           y: targetNode.y
         };
         
+        // Store the source and target points for label positioning
+        d.pathPoints = { source: sourcePoint, target: targetPoint };
+        
         // Direct line for debugging
         if (window.debugMode) {
           const sourceX = sourceNode.x;
@@ -2106,23 +2134,50 @@ function ticked() {
         
         // Adjust path drawing based on whether this is a connection from/to root
         const isRootConnection = (sourceId === rootSubject || targetId === rootSubject);
-        const isSourceHigher = sourcePoint.y < targetPoint.y;
+        
+        // Check if this is a "Son of" relationship
+        const isSonOfRelation = d.label && (d.label.includes("Son of") || d.label.includes("Child of") || d.label.includes("Parent of") || d.label.includes("Father of") || d.label.includes("Mother of"));
         
         // Create path with more segments for hierarchical flow
         let path = '';
         
-        // Adjust target point to account for arrow
-        const targetPointWithOffset = {
-          x: targetPoint.x,
-          y: targetPoint.y
-        };
-
+        // For "Son of" relations, use a more prominent curve
+        if (isSonOfRelation) {
+          // Calculate midpoint with offset for a nice curve
+          const midX = (sourcePoint.x + targetPoint.x) / 2;
+          const midY = (sourcePoint.y + targetPoint.y) / 2;
+          
+          // Calculate a perpendicular vector to the line
+          const dx = targetPoint.x - sourcePoint.x;
+          const dy = targetPoint.y - sourcePoint.y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          
+          // Normalize and get perpendicular vector
+          const nx = dx / dist;
+          const ny = dy / dist;
+          const px = -ny;
+          const py = nx;
+          
+          // Create a large curve for "Son of" relationships
+          // The curve should extend away from the direct line to make space for the label
+          const curveOffset = dist * 0.3; // 30% of distance as curve height
+          
+          // Apply the curve offset
+          const ctrlX = midX + px * curveOffset;
+          const ctrlY = midY + py * curveOffset;
+          
+          // Use a quadratic curve for "Son of" relationships
+          path = `M${sourcePoint.x},${sourcePoint.y} Q${ctrlX},${ctrlY} ${targetPoint.x},${targetPoint.y}`;
+          
+          // Store control points for label positioning
+          d.curveControlPoints = { ctrlX, ctrlY };
+        }
         // For hierarchical layout, use different path strategies
-        if (isRootConnection) {
+        else if (isRootConnection) {
           // For connections involving the root, use more direct paths
           if (sourceId === rootSubject) {
             // Root to other nodes - create more spread out curves
-            const controlDistance = Math.abs(targetPoint.x - sourcePoint.x) * 0.5;
+            const controlDistance = Math.abs(targetPoint.x - sourcePoint.x) * 0.3;
             const midY = sourcePoint.y + (targetPoint.y - sourcePoint.y) * 0.4;
             
             // Use bezier curves with control points that spread out more
@@ -2130,15 +2185,31 @@ function ticked() {
                     C${sourcePoint.x},${sourcePoint.y + controlDistance} 
                     ${targetPoint.x},${targetPoint.y - controlDistance} 
                     ${targetPoint.x},${targetPoint.y}`;
+            
+            // Store control points for label positioning
+            d.curveControlPoints = { 
+              ctrl1X: sourcePoint.x, 
+              ctrl1Y: sourcePoint.y + controlDistance,
+              ctrl2X: targetPoint.x, 
+              ctrl2Y: targetPoint.y - controlDistance 
+            };
           } else {
             // Other nodes to root - create more spread out curves going upward
-            const controlDistance = Math.abs(sourcePoint.x - targetPoint.x) * 0.5;
+            const controlDistance = Math.abs(sourcePoint.x - targetPoint.x) * 0.3;
             
             // Use bezier curves with control points that spread out more
             path = `M${sourcePoint.x},${sourcePoint.y} 
                     C${sourcePoint.x},${sourcePoint.y - controlDistance} 
                     ${targetPoint.x},${targetPoint.y + controlDistance} 
                     ${targetPoint.x},${targetPoint.y}`;
+            
+            // Store control points for label positioning
+            d.curveControlPoints = { 
+              ctrl1X: sourcePoint.x, 
+              ctrl1Y: sourcePoint.y - controlDistance,
+              ctrl2X: targetPoint.x, 
+              ctrl2Y: targetPoint.y + controlDistance 
+            };
           }
         } else {
           // For connections between non-root nodes
@@ -2191,7 +2262,7 @@ function ticked() {
         // Store the path points for label positioning
         d.pathPoints = {
           source: sourcePoint,
-          target: targetPointWithOffset,
+          target: targetPoint,
           isHorizontal: Math.abs(sourcePoint.x - targetPoint.x) > Math.abs(sourcePoint.y - targetPoint.y)
         };
         
@@ -2211,17 +2282,6 @@ function ticked() {
         
         const { source, target } = d.pathPoints;
         const labelEl = d3.select(this);
-        
-        // Calculate basic position for labels
-        let labelX, labelY;
-        
-        // Create a unique identifier for this edge to ensure consistent offsets
-        const edgeId = `${d.from}-${d.to}`;
-        // Create a hash from the edge ID to get a deterministic but varied offset
-        const hash = Math.abs(edgeId.split('').reduce((a, b) => {
-          a = ((a << 5) - a) + b.charCodeAt(0);
-          return a & a;
-        }, 0));
         
         // Get nodes from source and target IDs
         const sourceNode = nodeMap.get(d.from);
@@ -2247,30 +2307,77 @@ function ticked() {
         const px = -ny;
         const py = nx;
         
-        if (isRootConnection) {
-          // For connections with root
-          const t = isFromRoot ? 0.35 : 0.65; // Position along the path
-          
-          // Calculate base position along the path
-          labelX = source.x + dx * t;
-          labelY = source.y + dy * t;
-          
-          // Apply a perpendicular offset based on hash
-          const perpOffset = 60 + (hash % 40); // 60-100px perpendicular offset
-          labelX += px * perpOffset;
-          labelY += py * perpOffset;
+        // Get actual path element for this edge to find points along the path
+        const pathElement = linkElements.filter(e => e.from === d.from && e.to === d.to).node();
+        let labelX, labelY;
+        
+        if (pathElement) {
+          try {
+            // Get the total length of the path
+            const pathLength = pathElement.getTotalLength();
+            
+            // Position the label at a specific point along the path
+            // Root connections might need different positioning
+            let pathPosition;
+            
+            if (isRootConnection) {
+              pathPosition = isFromRoot ? 0.4 : 0.6; // Position along the path
+            } else {
+              pathPosition = 0.5; // Middle of the path for non-root connections
+            }
+            
+            // Get the point at the desired position along the path
+            const point = pathElement.getPointAtLength(pathLength * pathPosition);
+            labelX = point.x;
+            labelY = point.y;
+            
+            // Create a unique identifier for this edge to ensure consistent offsets
+            const edgeId = `${d.from}-${d.to}`;
+            // Create a hash from the edge ID to get a deterministic but varied offset
+            const hash = Math.abs(edgeId.split('').reduce((a, b) => {
+              a = ((a << 5) - a) + b.charCodeAt(0);
+              return a & a;
+            }, 0));
+            
+            // For curves, we might need to adjust the perpendicular offset
+            // Get points slightly before and after the current point to determine the tangent
+            const pointBefore = pathElement.getPointAtLength(Math.max(0, pathLength * pathPosition - 10));
+            const pointAfter = pathElement.getPointAtLength(Math.min(pathLength, pathLength * pathPosition + 10));
+            
+            // Calculate the tangent vector at this point
+            const tangentX = pointAfter.x - pointBefore.x;
+            const tangentY = pointAfter.y - pointBefore.y;
+            const tangentLength = Math.sqrt(tangentX * tangentX + tangentY * tangentY);
+            
+            // Normalize the tangent vector
+            const tnx = tangentX / tangentLength;
+            const tny = tangentY / tangentLength;
+            
+            // Calculate the perpendicular vector to the tangent
+            const tpx = -tny;
+            const tpy = tnx;
+            
+            // Apply a small perpendicular offset to ensure text is on the line but visible
+            const perpOffset = 15 + (hash % 10); // Smaller offset - just enough to not overlap the line
+            
+            // Use a deterministic but varied sign for the offset
+            const sign = ((hash % 2) * 2 - 1); // Either 1 or -1
+            labelX += tpx * perpOffset * sign;
+            labelY += tpy * perpOffset * sign;
+          } catch (e) {
+            console.warn("Error positioning label on path:", e);
+            
+            // Fallback to simple midpoint positioning
+            labelX = source.x + dx * 0.5;
+            labelY = source.y + dy * 0.5;
+          }
         } else {
-          // For non-root connections, position at midpoint with perpendicular offset
+          // Fallback if path element not found
+          console.warn("Path element not found for label positioning");
+          
+          // Position at midpoint with offset
           labelX = source.x + dx * 0.5;
           labelY = source.y + dy * 0.5;
-          
-          // Apply larger perpendicular offset based on hash
-          const perpOffset = 80 + (hash % 60); // 80-140px perpendicular offset
-          
-          // Use a deterministic but varied sign for the offset
-          const sign = ((hash % 2) * 2 - 1); // Either 1 or -1
-          labelX += px * perpOffset * sign;
-          labelY += py * perpOffset * sign;
         }
         
         // Get text elements to calculate size
@@ -2301,15 +2408,14 @@ function ticked() {
             .attr('height', labelHeight)
             .attr('x', -labelWidth / 2)
             .attr('y', -labelHeight / 2);
+          
+          // Update the text position to match the background
+          labelEl.attr('transform', `translate(${labelX},${labelY})`);
+          
+          // Store the position for use in interactions
+          d.labelX = labelX;
+          d.labelY = labelY;
         }
-        
-        // Apply the transform to position the label
-        labelEl.attr('transform', `translate(${labelX}, ${labelY})`);
-        
-        // Store position for collision detection
-        d.labelX = labelX;
-        d.labelY = labelY;
-        
       } catch (error) {
         console.error("Error positioning label:", error);
       }
@@ -2844,6 +2950,25 @@ function getNodeLayer(nodeId, edgesParam) {
   
   return 3; // Everything else is layer 3 or beyond
 }
+
+// Add text to labels
+labelElements.append('text')
+  .attr('class', 'link-label')
+  .attr('text-anchor', 'middle')
+  .attr('dominant-baseline', 'middle')
+  .attr('fill', '#374151')
+  .style('pointer-events', 'none')
+  .style('font-size', '12px')
+  .style('font-weight', 'bold')
+  .text(function(d) {
+    // For "Son of" relationships, highlight them with a special format
+    if (d.label && (d.label.includes("Son of") || d.label.includes("Child of") || 
+                    d.label.includes("Parent of") || d.label.includes("Father of") || 
+                    d.label.includes("Mother of"))) {
+      return d.label;
+    }
+    return d.label || '';
+  });
 </script>
 </body>
 </html>

--- a/relations/index.html
+++ b/relations/index.html
@@ -1172,10 +1172,11 @@ function initializeD3Graph() {
 }
 
 function resetZoom() {
-  // Center the graph with an appropriate scale
+  // Center the graph with an appropriate scale for hierarchical layout
+  // In hierarchical layout, we want to center more towards the top where the root node is
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(0, 0).scale(0.5) // More zoomed out to see the entire graph
+    d3.zoomIdentity.translate(0, height * 0.2).scale(0.5) // Shift up slightly to focus on root
   );
 }
 
@@ -1191,10 +1192,22 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Update loading text to show that the graph is being processed
   $('#loading-text').text('Rendering graph visualization...');
   
+  // Add a timeout to ensure loading overlay is hidden even if other mechanisms fail
+  setTimeout(() => {
+    console.log("Timeout check - ensuring loading overlay is hidden");
+    if (document.getElementById('loading')) {
+      document.getElementById('loading').style.display = 'none';
+    }
+    $('#loading-indicator').hide();
+  }, 10000); // 10 seconds should be plenty for the graph to render
+  
   // Initialize container dimensions
   const container = document.getElementById('graph-container');
   width = container.clientWidth;
   height = container.clientHeight;
+  
+  // Make edges available globally to prevent "edges is not defined" errors
+  window.edges = edges;
   
   // Initialize zoom behavior if not already done
   if (!zoom) {
@@ -1235,26 +1248,29 @@ function renderD3Graph(rootSubject, nodes, edges) {
     nodeMap.set(node.id, node);
   });
   
-  // Pre-position nodes in a structured layout
-  // Position root node in the center
+  // Pre-position nodes in a structured layout - critical for avoiding initial overlaps
+  // Position root node at the top center
   if (rootNode) {
-    rootNode.x = 0; // Position at origin (will be transformed to center)
-    rootNode.y = 0; // Position at origin (will be transformed to center)
-    rootNode.fx = 0; // Fix position at origin
-    rootNode.fy = 0; // Fix position at origin
+    rootNode.x = 0; // Center horizontally
+    rootNode.y = -height * 0.35; // Position at top
+    rootNode.fx = 0; // Fix position horizontally
+    rootNode.fy = -height * 0.35; // Fix position vertically
   }
   
-  // Arrange non-root nodes in a circle around the root node at the origin
+  // Arrange non-root nodes in a semi-circle below the root node
   const radius = Math.min(width, height) * 0.25; // Use 25% of the smaller dimension for radius
   nonRootNodes.forEach((node, i) => {
-    const angle = (i * 2 * Math.PI) / nonRootNodes.length;
-    node.x = radius * Math.cos(angle); // Position relative to origin
-    node.y = radius * Math.sin(angle); // Position relative to origin
-    // Don't fix these positions completely, allow force layout to adjust
+    // Use a semi-circle (180 degrees) below the root
+    const angle = (Math.PI * i) / (nonRootNodes.length - 1);
+    node.x = radius * Math.cos(angle); // Position in semi-circle
+    node.y = -height * 0.35 + radius * Math.sin(angle) + radius; // Position below root node
   });
   
   // Preprocess edges to ensure all source and target nodes exist
   console.log(`Processing ${edges.length} edges...`);
+  
+  // Create validEdges variable that references the edges array
+  // This ensures validEdges is defined for any code that references it
   const validEdges = edges.filter(edge => {
     const sourceId = edge.from;
     const targetId = edge.to;
@@ -1281,6 +1297,21 @@ function renderD3Graph(rootSubject, nodes, edges) {
   });
   
   console.log(`Filtered to ${validEdges.length} valid edges`);
+  
+  // Identify first-level nodes (directly connected to root)
+  const firstLevelNodeIds = new Set();
+  validEdges.forEach(edge => {
+    if (edge.from === rootSubject) {
+      firstLevelNodeIds.add(edge.to);
+      console.log(`Added first-level node from root: ${edge.to} via relation: ${edge.label || "unlabeled"}`);
+    } else if (edge.to === rootSubject) {
+      firstLevelNodeIds.add(edge.from);
+      console.log(`Added first-level node to root: ${edge.from} via relation: ${edge.label || "unlabeled"}`);
+    }
+  });
+  
+  console.log(`Identified ${firstLevelNodeIds.size} first-level nodes`);
+  console.log('First-level nodes:', Array.from(firstLevelNodeIds));
   
   // Add arrow markers for links
   const defs = g.append('defs');
@@ -1358,7 +1389,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .on('drag', dragged)
       .on('end', dragEnded)
     );
-    
+   
   // Add rectangles to nodes
   nodeElements.append('rect')
     .attr('rx', 4)
@@ -1461,30 +1492,140 @@ function renderD3Graph(rootSubject, nodes, edges) {
     
   // Add text labels with wrapping
   labelElements.each(function(d) {
-    const labelGroup = d3.select(this);
-    const label = d.label || "";
-    
-    // Skip empty labels
-    if (!label.trim()) {
-      labelGroup.append('text')
-        .attr('class', 'link-label')
-        .attr('fill', '#475569')
-        .text("");
-      return;
+    try {
+      const labelGroup = d3.select(this);
+      const label = d.label || "";
+      
+      // Skip empty labels
+      if (!label.trim()) {
+        labelGroup.append('text')
+          .attr('class', 'link-label')
+          .attr('fill', '#475569')
+          .text("");
+        return;
+      }
+      
+      // Wrap text to max 20 characters per line
+      const wrappedText = wrapText(label, 20);
+      
+      // Add each line of text
+      wrappedText.forEach((line, i) => {
+        labelGroup.append('text')
+          .attr('class', 'link-label')
+          .attr('fill', '#475569')
+          .attr('text-anchor', 'middle') // Center text
+          .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
+          .text(line);
+      });
+      
+      if (!d.pathPoints) {
+        return;
+      }
+      
+      const { source, target } = d.pathPoints;
+      const labelEl = d3.select(this);
+      
+      // Calculate basic position for labels
+      let labelX, labelY;
+      
+      // Create a unique identifier for this edge to ensure consistent offsets
+      const edgeId = `${d.from}-${d.to}`;
+      // Create a hash from the edge ID to get a deterministic but varied offset
+      const hash = Math.abs(edgeId.split('').reduce((a, b) => {
+        a = ((a << 5) - a) + b.charCodeAt(0);
+        return a & a;
+      }, 0));
+      
+      // Get nodes from source and target IDs
+      const sourceNode = nodeMap.get(d.from);
+      const targetNode = nodeMap.get(d.to);
+      
+      // Skip if nodes not found
+      if (!sourceNode || !targetNode) return;
+      
+      // Detect if this is a root connection
+      const isRootConnection = (d.from === rootSubject || d.to === rootSubject);
+      const isFromRoot = d.from === rootSubject;
+      
+      // Calculate the distance between nodes
+      const dx = target.x - source.x;
+      const dy = target.y - source.y;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      
+      // Normalize the direction vector
+      const nx = dx / distance;
+      const ny = dy / distance;
+      
+      // Create perpendicular vector for offset
+      const px = -ny;
+      const py = nx;
+      
+      if (isRootConnection) {
+        // For connections with root
+        const t = isFromRoot ? 0.35 : 0.65; // Position along the path
+        
+        // Calculate base position along the path
+        labelX = source.x + dx * t;
+        labelY = source.y + dy * t;
+        
+        // Apply a perpendicular offset based on hash
+        const perpOffset = 60 + (hash % 40); // 60-100px perpendicular offset
+        labelX += px * perpOffset;
+        labelY += py * perpOffset;
+      } else {
+        // For non-root connections, position at midpoint with perpendicular offset
+        labelX = source.x + dx * 0.5;
+        labelY = source.y + dy * 0.5;
+        
+        // Apply larger perpendicular offset based on hash
+        const perpOffset = 80 + (hash % 60); // 80-140px perpendicular offset
+        
+        // Use a deterministic but varied sign for the offset
+        const sign = ((hash % 2) * 2 - 1); // Either 1 or -1
+        labelX += px * perpOffset * sign;
+        labelY += py * perpOffset * sign;
+      }
+      
+      // Get text elements to calculate size
+      const textElements = labelEl.selectAll('text.link-label');
+      
+      if (textElements.size() > 0) {
+        let labelWidth = 0;
+        let labelHeight = 0;
+        
+        // Calculate total width and height based on all text elements
+        textElements.each(function() {
+          try {
+            const bbox = this.getBBox();
+            labelWidth = Math.max(labelWidth, bbox.width);
+            labelHeight += bbox.height;
+          } catch (e) {
+            console.log("Error getting text bounding box", e);
+          }
+        });
+        
+        // Add more padding
+        labelWidth += 30;
+        labelHeight += 16;
+        
+        // Update background rectangle size
+        labelEl.select('rect.label-bg')
+          .attr('width', labelWidth)
+          .attr('height', labelHeight)
+          .attr('x', -labelWidth / 2)
+          .attr('y', -labelHeight / 2);
+      }
+      
+      // Apply the transform to position the label
+      labelEl.attr('transform', `translate(${labelX}, ${labelY})`);
+      
+      // Store position for collision detection
+      d.labelX = labelX;
+      d.labelY = labelY;
+      
+    } catch (error) {
+      console.error("Error positioning label:", error);
     }
-    
-    // Wrap text to max 20 characters per line
-    const wrappedText = wrapText(label, 20);
-    
-    // Add each line of text
-    wrappedText.forEach((line, i) => {
-      labelGroup.append('text')
-        .attr('class', 'link-label')
-        .attr('fill', '#475569')
-        .attr('text-anchor', 'middle') // Center text
-        .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
-        .text(line);
-    });
   });
   
   // Helper function to highlight a connection between two nodes
@@ -1567,35 +1708,125 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .attr('fill', '#475569');
   }
   
-  // Start the simulation with modified forces for structured layout
+  // First run the simulation without rendering for many iterations
+  // This helps find a better layout before rendering
+  let tempSimulation = d3.forceSimulation(nodes)
+    .force('link', d3.forceLink()
+      .links(edges)
+      .id(d => d.id)
+      .distance(d => {
+        // Vary distance based on connection type
+        if (d.from === rootSubject || d.to === rootSubject) {
+          return 350; // Root connections get even more space
+        }
+        return 250; // More space for other connections
+      }))
+    .force('charge', d3.forceManyBody()
+      .strength(d => d.id === rootSubject ? -2500 : -1500)) // Stronger repulsion
+    .force('x', d3.forceX(d => {
+      if (d.id === rootSubject) return 0;
+      if (firstLevelNodeIds.has(d.id)) {
+        return d.x * 1.7; // Push first level nodes further out horizontally
+      }
+      return d.x;
+    }).strength(0.25))
+    .force('y', d3.forceY(d => {
+      if (d.id === rootSubject) return -height * 0.4;
+      if (firstLevelNodeIds.has(d.id)) {
+        return d.y; // Keep first level at their y positions
+      }
+      return height * 0.35; // Push other nodes down more
+    }).strength(0.25))
+    .force('collision', d3.forceCollide()
+      .radius(d => {
+        // Even larger collision radius to keep nodes well separated
+        const nodeWidth = getNodeWidth(d);
+        const nodeHeight = getNodeHeight(d);
+        
+        if (d.id === rootSubject) {
+          return Math.sqrt(nodeWidth * nodeHeight) + 180;
+        }
+        return Math.sqrt(nodeWidth * nodeHeight) + 130;
+      })
+      .strength(1)) // Full collision strength
+    .stop();
+  
+  // Run the pre-positioning simulation for more iterations
+  for (let i = 0; i < 150; i++) {
+    tempSimulation.tick();
+  }
+  
+  // Now create the actual simulation for rendering
   simulation = d3.forceSimulation(nodes)
     .force('link', d3.forceLink()
-      .links(validEdges)
+      .links(edges)
       .id(d => d.id)
-      .distance(forceParams.linkDistance * 2)) // Double the link distance
+      .distance(d => {
+        // Use different distances for different types of connections
+        if (d.from === rootSubject || d.to === rootSubject) {
+          return forceParams.linkDistance * 10; // More space for root connections
+        }
+        return forceParams.linkDistance * 7; // More space for non-root connections
+      }))
     .force('charge', d3.forceManyBody()
       .strength(d => {
-        // Stronger repulsion for structured layout
+        // Use stronger repulsion for the root
+        if (d.id === rootSubject) {
+          return forceParams.charge * -20;
+        }
+        // Use node size to scale repulsion
         const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
-        return forceParams.charge * (nodeSize / 200) * 2.5; // Significantly increased repulsion
+        return forceParams.charge * (nodeSize / 150) * -15;
       })
-      .distanceMin(400) // Increased minimum distance
-      .distanceMax(5000)) // Increased maximum distance
-    .force('x', d3.forceX(0).strength(0.2)) // Center nodes horizontally at origin
-    .force('y', d3.forceY(0).strength(0.2)) // Center nodes vertically at origin
+      .distanceMin(900)
+      .distanceMax(12000))
+    .force('x', d3.forceX(d => {
+      // Root node stays at center
+      if (d.id === rootSubject) return 0;
+      
+      // First level nodes maintain their existing x position but with scaling
+      if (firstLevelNodeIds.has(d.id)) {
+        return d.x * 1.3; // Expand the first level more
+      }
+      
+      // Second level nodes spread wider
+      return d.x * 1.4;
+    }).strength(d => d.id === rootSubject ? 1 : 0.2))
+    .force('y', d3.forceY(d => {
+      // Keep root at top
+      if (d.id === rootSubject) return -height * 0.4;
+      
+      // First level nodes position
+      if (firstLevelNodeIds.has(d.id)) {
+        return d.y * 0.95; // Keep in their semi-circle but slightly tighter
+      }
+      
+      // Second level nodes position
+      return d.y * 1.3; // Push further down
+    }).strength(d => d.id === rootSubject ? 1 : 0.35))
     .force('collision', d3.forceCollide().radius(d => {
-      // Make collision radius based on node size plus padding
+      // Use much larger collision radius
       const nodeWidth = getNodeWidth(d);
       const nodeHeight = getNodeHeight(d);
-      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 200; // Significantly increased padding
-    }).strength(1))
-    .alpha(0.8) // Higher alpha for more movement
-    .alphaDecay(0.01) // Slower decay for more time to find optimal positions
-    .velocityDecay(0.4)
+      // Different collision radii based on node type
+      if (d.id === rootSubject) {
+        return Math.sqrt(nodeWidth * nodeHeight) + 180;
+      }
+      return Math.sqrt(nodeWidth * nodeHeight) + 130;
+    }).strength(0.95).iterations(4)) // More iterations for better collision resolution
+    .alpha(0.4) // Start with lower alpha since we've pre-positioned
+    .alphaDecay(0.003) // Slower decay for more gradual layout
+    .velocityDecay(0.25) // Adjust velocity decay for smoother movement
     .on('tick', ticked)
     .on('end', () => {
       // When the simulation ends, center the graph based on actual content bounds
       centerGraph();
+      
+      // Failsafe: directly hide loading elements in case centerGraph didn't do it
+      console.log("Simulation ended - ensuring loading overlay is hidden");
+      document.getElementById('loading').style.display = 'none';
+      $('#loading-indicator').hide();
+      $('#loading-overlay').hide();
     });
 }
 
@@ -1604,269 +1835,376 @@ function centerGraph() {
   try {
     // Get the bounding box of the graph content
     const bbox = document.getElementById('graph-content').getBBox();
+    console.log("Graph bbox:", bbox);
     
-    // Calculate the center of the graph content
+    // Calculate the dimensions of the viewport
+    const viewportWidth = width;
+    const viewportHeight = height;
+    console.log("Viewport dimensions:", viewportWidth, viewportHeight);
+    
+    // Calculate the center of the graph content with emphasis on the root node
+    // For knowledge graphs, we want the root higher in the viewport
     const graphCenterX = bbox.x + bbox.width / 2;
-    const graphCenterY = bbox.y + bbox.height / 2;
+    const graphCenterY = bbox.y + bbox.height * 0.35; // 35% point to shift focus upward
     
     // Calculate the translation needed to center the graph
-    const translateX = width / 2 - graphCenterX;
-    const translateY = height / 2 - graphCenterY;
+    const translateX = viewportWidth / 2 - graphCenterX;
+    const translateY = viewportHeight / 2 - graphCenterY;
+    console.log("Translation:", translateX, translateY);
     
-    // Update the zoom transform to center the graph
-    d3.select('#graph').call(
-      zoom.transform,
-      d3.zoomIdentity.translate(translateX, translateY).scale(0.5)
+    // Determine appropriate initial scale based on the graph size
+    // We want to fit the graph with some margin
+    let initialScale = Math.min(
+      viewportWidth / (bbox.width * 1.25),  // 25% margin horizontally
+      viewportHeight / (bbox.height * 1.25) // 25% margin vertically
     );
     
-    console.log('Graph centered based on actual bounds:', { 
-      bbox, 
-      graphCenter: { x: graphCenterX, y: graphCenterY },
-      translation: { x: translateX, y: translateY }
-    });
+    // Limit scale to reasonable bounds
+    initialScale = Math.min(Math.max(initialScale, 0.15), 0.75);
+    console.log("Initial scale:", initialScale);
     
-    // Hide the loading overlay when the graph is fully loaded and centered
-    const loadingEl = document.getElementById('loading');
-    if (loadingEl) {
-      loadingEl.style.opacity = '0';
-      loadingEl.style.transition = 'opacity 0.3s ease-out';
-      setTimeout(() => {
-        loadingEl.style.display = 'none';
-      }, 300);
-    }
+    // Update the zoom transform to center the graph with appropriate scale
+    d3.select('#graph').call(
+      zoom.transform,
+      d3.zoomIdentity
+        .translate(translateX, translateY)
+        .scale(initialScale)
+    );
+    
+    // Hide loading overlay and indicators
+    document.getElementById('loading').style.display = 'none';
+    $('#loading-indicator').hide();
+    $('#loading-overlay').fadeOut();
+    
+    console.log("Loading overlay hidden");
   } catch (error) {
-    console.error('Error centering graph:', error);
+    console.error("Error centering graph:", error);
   }
 }
 
-// Update the ticked function to properly position nodes, links, and labels
+// Function for updating element positions on tick
 function ticked() {
   try {
-    // Update node positions
-    nodeElements.attr('transform', d => {
-      // Constrain to bounds relative to origin
-      const halfWidth = width / 2;
-      const halfHeight = height / 2;
-      d.x = Math.max(-halfWidth + 50, Math.min(halfWidth - 50, d.x));
-      d.y = Math.max(-halfHeight + 50, Math.min(halfHeight - 50, d.y));
-      return `translate(${d.x - getNodeWidth(d) / 2}, ${d.y - getNodeHeight(d) / 2})`;
+    // Keep the root node fixed at the top
+    simulation.nodes().forEach(d => {
+      if (d.id === rootSubject) {
+        d.x = 0;
+        d.y = -height * 0.4;
+        d.fx = 0;
+        d.fy = -height * 0.4;
+      }
     });
     
-    // Update link paths with improved orthogonal routing
-    linkElements.attr('d', d => {
+    // Get the bounds of the available canvas area
+    const graphWidth = width * 2;  // Make the bounding box larger than the visible area
+    const graphHeight = height * 2;
+    
+    // Add border constraints - keep nodes within bounds
+    simulation.nodes().forEach(function(d) {
+      // Don't apply to fixed nodes (like the root)
+      if (d.fx !== undefined || d.fy !== undefined) return;
+      
+      // Don't let nodes go too far off-canvas
+      const nodeWidth = getNodeWidth(d);
+      const nodeHeight = getNodeHeight(d);
+      
+      // Softer constraints - gradually increase force as nodes approach edges
+      const margin = 200; // Increased margin
+      
+      // X bounds
+      const xMin = -graphWidth/2 + nodeWidth/2 + margin;
+      const xMax = graphWidth/2 - nodeWidth/2 - margin;
+      
+      // Y bounds - allow more space at the top for the hierarchical layout
+      const yMin = -graphHeight/2 + nodeHeight/2 + margin;
+      const yMax = graphHeight/2 - nodeHeight/2 - margin;
+      
+      if (d.x < xMin) {
+        d.x = xMin + (d.x - xMin) * 0.1; // gradual enforcement
+        d.vx = Math.abs(d.vx) * 0.5; // dampen velocity and reverse direction
+      }
+      if (d.x > xMax) {
+        d.x = xMax - (xMax - d.x) * 0.1; // gradual enforcement
+        d.vx = -Math.abs(d.vx) * 0.5; // dampen velocity and reverse direction
+      }
+      
+      if (d.y < yMin) {
+        d.y = yMin + (d.y - yMin) * 0.1; // gradual enforcement
+        d.vy = Math.abs(d.vy) * 0.5; // dampen velocity and reverse direction
+      }
+      if (d.y > yMax) {
+        d.y = yMax - (yMax - d.y) * 0.1; // gradual enforcement
+        d.vy = -Math.abs(d.vy) * 0.5; // dampen velocity and reverse direction
+      }
+    });
+    
+    // Update node positions
+    nodeElements.attr('transform', d => `translate(${d.x - getNodeWidth(d) / 2},${d.y - getNodeHeight(d) / 2})`);
+    
+    // Helper function to get node layer for path generation
+    function getNodeLayer(nodeId, edgesList) {
+      // Root is always layer 0
+      if (nodeId === rootSubject) return 0;
+      
+      // First level: directly connected to root
+      const isConnectedToRoot = edgesList.some(e => 
+        (e.from === rootSubject && e.to === nodeId) || 
+        (e.to === rootSubject && e.from === nodeId)
+      );
+      
+      if (isConnectedToRoot) return 1;
+      
+      // Otherwise it's a deeper level
+      return 2;
+    }
+    
+    // Update link positions with more advanced path generation
+    linkElements.attr('d', function(d) {
       try {
-        // Get source and target IDs
         const sourceId = d.from;
         const targetId = d.to;
         
-        if (!sourceId || !targetId) {
-          console.warn("Missing source or target ID in link path calculation:", d);
-          return '';
-        }
-        
-        // Get the actual node objects using the nodeMap
+        // Get source and target nodes from the ID
         const sourceNode = nodeMap.get(sourceId);
         const targetNode = nodeMap.get(targetId);
         
         if (!sourceNode || !targetNode) {
-          console.warn("Missing node for link in ticked:", 
-                      !sourceNode ? `source: ${sourceId}` : `target: ${targetId}`);
+          console.warn(`Missing node data for ${sourceId} or ${targetId}`);
           return '';
         }
         
-        // Calculate dimensions
-        const sourceWidth = getNodeWidth(sourceNode);
-        const sourceHeight = getNodeHeight(sourceNode);
-        const targetWidth = getNodeWidth(targetNode);
-        const targetHeight = getNodeHeight(targetNode);
+        // Calculate source and target points
+        const sourcePoint = {
+          x: sourceNode.x,
+          y: sourceNode.y
+        };
         
-        // Calculate source and target centers
-        const sourceX = sourceNode.x;
-        const sourceY = sourceNode.y;
-        const targetX = targetNode.x;
-        const targetY = targetNode.y;
+        const targetPoint = {
+          x: targetNode.x,
+          y: targetNode.y
+        };
         
-        // Find intersection points with rectangles
-        const sourcePoint = findIntersectionPoint(
-          sourceX, sourceY, targetX, targetY,
-          sourceX - sourceWidth/2, sourceY - sourceHeight/2,
-          sourceWidth, sourceHeight
-        );
-        
-        const targetPoint = findIntersectionPoint(
-          targetX, targetY, sourceX, sourceY,
-          targetX - targetWidth/2, targetY - targetHeight/2,
-          targetWidth, targetHeight
-        );
-        
-        if (!sourcePoint || !targetPoint) {
-          console.warn("Could not find intersection points for link:", sourceId, targetId);
-          // Fallback to direct line between centers
+        // Direct line for debugging
+        if (window.debugMode) {
+          const sourceX = sourceNode.x;
+          const sourceY = sourceNode.y;
+          const targetX = targetNode.x;
+          const targetY = targetNode.y;
           return `M${sourceX},${sourceY} L${targetX},${targetY}`;
         }
         
-        // Create orthogonal (right-angled) paths with better routing
-        // Calculate if nodes are more horizontal or vertical to each other
-        const dx = Math.abs(targetPoint.x - sourcePoint.x);
-        const dy = Math.abs(targetPoint.y - sourcePoint.y);
-        const isHorizontal = dx > dy;
+        // Adjust path drawing based on whether this is a connection from/to root
+        const isRootConnection = (sourceId === rootSubject || targetId === rootSubject);
+        const isSourceHigher = sourcePoint.y < targetPoint.y;
         
-        // Create path with more segments to avoid running behind nodes
+        // Create path with more segments for hierarchical flow
         let path = '';
         
-        // Remove the offset to ensure lines connect directly to nodes without gaps
-        const arrowOffset = 0;
-        
-        // Adjust target point to account for arrow - no offset to avoid gaps
+        // Adjust target point to account for arrow
         const targetPointWithOffset = {
           x: targetPoint.x,
           y: targetPoint.y
         };
-        
-        if (isHorizontal) {
-          // For horizontal arrangement, use 3 segments with vertical middle segment
-          const midX = (sourcePoint.x + targetPointWithOffset.x) / 2;
-          path = `M${sourcePoint.x},${sourcePoint.y} 
-                  L${midX},${sourcePoint.y} 
-                  L${midX},${targetPointWithOffset.y} 
-                  L${targetPointWithOffset.x},${targetPointWithOffset.y}`;
+
+        // For hierarchical layout, use different path strategies
+        if (isRootConnection) {
+          // For connections involving the root, use more direct paths
+          if (sourceId === rootSubject) {
+            // Root to other nodes - create more spread out curves
+            const controlDistance = Math.abs(targetPoint.x - sourcePoint.x) * 0.5;
+            const midY = sourcePoint.y + (targetPoint.y - sourcePoint.y) * 0.4;
+            
+            // Use bezier curves with control points that spread out more
+            path = `M${sourcePoint.x},${sourcePoint.y} 
+                    C${sourcePoint.x},${sourcePoint.y + controlDistance} 
+                    ${targetPoint.x},${targetPoint.y - controlDistance} 
+                    ${targetPoint.x},${targetPoint.y}`;
+          } else {
+            // Other nodes to root - create more spread out curves going upward
+            const controlDistance = Math.abs(sourcePoint.x - targetPoint.x) * 0.5;
+            
+            // Use bezier curves with control points that spread out more
+            path = `M${sourcePoint.x},${sourcePoint.y} 
+                    C${sourcePoint.x},${sourcePoint.y - controlDistance} 
+                    ${targetPoint.x},${targetPoint.y + controlDistance} 
+                    ${targetPoint.x},${targetPoint.y}`;
+          }
         } else {
-          // For vertical arrangement, use 3 segments with horizontal middle segment
-          const midY = (sourcePoint.y + targetPointWithOffset.y) / 2;
-          path = `M${sourcePoint.x},${sourcePoint.y} 
-                  L${sourcePoint.x},${midY} 
-                  L${targetPointWithOffset.x},${midY} 
-                  L${targetPointWithOffset.x},${targetPointWithOffset.y}`;
+          // For connections between non-root nodes
+          // Calculate the "layer" of the node based on its position
+          const sourceLayer = getNodeLayer(sourceId, edges);
+          const targetLayer = getNodeLayer(targetId, edges);
+          
+          // Route differently based on whether nodes are on same layer or different layers
+          if (Math.abs(sourcePoint.y - targetPoint.y) > Math.abs(sourcePoint.x - targetPoint.x) * 1.2) {
+            // More vertical than horizontal - likely across layers
+            // Use S-curves for more separation between paths
+            const dx = targetPoint.x - sourcePoint.x;
+            const dy = targetPoint.y - sourcePoint.y;
+            
+            // Calculate offset based on the uniqueness of the connection
+            const connectionId = sourceId.length + targetId.length + sourcePoint.x;
+            const randomOffset = (connectionId % 100) / 100 * 0.4 + 0.3; // 0.3 to 0.7 range
+            
+            // Create control points for S-curve
+            const cp1x = sourcePoint.x + dx * 0.1;
+            const cp1y = sourcePoint.y + dy * randomOffset;
+            const cp2x = sourcePoint.x + dx * 0.9;
+            const cp2y = sourcePoint.y + dy * (1 - randomOffset);
+            
+            path = `M${sourcePoint.x},${sourcePoint.y} 
+                    C${cp1x},${cp1y} ${cp2x},${cp2y} ${targetPoint.x},${targetPoint.y}`;
+          } else if (Math.abs(sourceLayer - targetLayer) <= 1) {
+            // Nodes are on similar layers - use a curved path
+            const midX = (sourcePoint.x + targetPoint.x) / 2;
+            // Add some randomness to midY to reduce overlaps
+            const midYOffset = (sourceId.length + targetId.length) % 100;
+            const midY = (sourcePoint.y + targetPoint.y) / 2 + (midYOffset - 50);
+            
+            path = `M${sourcePoint.x},${sourcePoint.y} 
+                    Q${midX},${midY} ${targetPoint.x},${targetPoint.y}`;
+          } else {
+            // Significant horizontal distance - use orthogonal routing with randomized midpoints
+            const midX = (sourcePoint.x + targetPoint.x) / 2 + 
+                      ((sourceId.length * targetId.length) % 100 - 50);
+            const yDiff = Math.abs(targetPoint.y - sourcePoint.y);
+            const midY1 = sourcePoint.y + (isSourceHigher ? yDiff * 0.25 : -yDiff * 0.25);
+            const midY2 = targetPoint.y + (isSourceHigher ? -yDiff * 0.25 : yDiff * 0.25);
+            
+            path = `M${sourcePoint.x},${sourcePoint.y} 
+                    C${sourcePoint.x},${midY1} ${midX},${midY1} ${midX},${(midY1 + midY2) / 2}
+                    S${targetPoint.x},${midY2} ${targetPoint.x},${targetPoint.y}`;
+          }
         }
         
         // Store the path points for label positioning
         d.pathPoints = {
           source: sourcePoint,
           target: targetPointWithOffset,
-          isHorizontal: isHorizontal
+          isHorizontal: Math.abs(sourcePoint.x - targetPoint.x) > Math.abs(sourcePoint.y - targetPoint.y)
         };
         
         return path;
       } catch (error) {
-        console.error("Error in link path calculation:", error, d);
+        console.error("Error generating link path:", error);
         return '';
       }
     });
     
-    // Update label positions
+    // Update label positions on the links
     labelElements.each(function(d) {
       try {
-        const labelGroup = d3.select(this);
-        
-        // Get source and target IDs
-        const sourceId = d.from;
-        const targetId = d.to;
-        
-        if (!sourceId || !targetId) {
-          console.warn("Missing source or target ID in label positioning");
+        if (!d.pathPoints) {
           return;
         }
         
-        // Find the path element for this edge
-        const path = d3.select(`path.link[data-source="${sourceId}"][data-target="${targetId}"]`).node();
+        const { source, target } = d.pathPoints;
+        const labelEl = d3.select(this);
         
-        let midX, midY;
+        // Calculate basic position for labels
+        let labelX, labelY;
         
-        // If we have a path, position the label at its midpoint
-        if (path) {
-          const pathLength = path.getTotalLength();
-          if (pathLength) {
-            // Store the path for later use in overlap prevention
-            d.path = path;
-            
-            // Get the midpoint of the path
-            const midPoint = path.getPointAtLength(pathLength / 2);
-            midX = midPoint.x;
-            midY = midPoint.y;
-            
-            // If we have stored path points, use them for better label positioning
-            if (d.pathPoints) {
-              const { source, target, isHorizontal } = d.pathPoints;
-              
-              if (isHorizontal) {
-                // For horizontal paths, position label above or below the middle segment
-                const midX = (source.x + target.x) / 2;
-                midY = source.y + (target.y - source.y) / 2;
-                
-                // Increase offset to avoid overlap
-                midY += (source.y > target.y) ? -40 : 40;
-              } else {
-                // For vertical paths, position label to the left or right of the middle segment
-                midX = source.x + (target.x - source.x) / 2;
-                const midY = (source.y + target.y) / 2;
-                
-                // Increase offset to avoid overlap
-                midX += (source.x > target.x) ? -40 : 40;
-              }
-            }
-          } else {
-            // Fallback if path length is 0
-            const sourceNode = nodeMap.get(sourceId);
-            const targetNode = nodeMap.get(targetId);
-            
-            if (!sourceNode || !targetNode) {
-              console.warn("Missing node in label positioning fallback");
-              return;
-            }
-            
-            midX = (sourceNode.x + targetNode.x) / 2;
-            midY = (sourceNode.y + targetNode.y) / 2;
-          }
+        // Create a unique identifier for this edge to ensure consistent offsets
+        const edgeId = `${d.from}-${d.to}`;
+        // Create a hash from the edge ID to get a deterministic but varied offset
+        const hash = Math.abs(edgeId.split('').reduce((a, b) => {
+          a = ((a << 5) - a) + b.charCodeAt(0);
+          return a & a;
+        }, 0));
+        
+        // Get nodes from source and target IDs
+        const sourceNode = nodeMap.get(d.from);
+        const targetNode = nodeMap.get(d.to);
+        
+        // Skip if nodes not found
+        if (!sourceNode || !targetNode) return;
+        
+        // Detect if this is a root connection
+        const isRootConnection = (d.from === rootSubject || d.to === rootSubject);
+        const isFromRoot = d.from === rootSubject;
+        
+        // Calculate the distance between nodes
+        const dx = target.x - source.x;
+        const dy = target.y - source.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        
+        // Normalize the direction vector
+        const nx = dx / distance;
+        const ny = dy / distance;
+        
+        // Create perpendicular vector for offset
+        const px = -ny;
+        const py = nx;
+        
+        if (isRootConnection) {
+          // For connections with root
+          const t = isFromRoot ? 0.35 : 0.65; // Position along the path
+          
+          // Calculate base position along the path
+          labelX = source.x + dx * t;
+          labelY = source.y + dy * t;
+          
+          // Apply a perpendicular offset based on hash
+          const perpOffset = 60 + (hash % 40); // 60-100px perpendicular offset
+          labelX += px * perpOffset;
+          labelY += py * perpOffset;
         } else {
-          // Fallback: position between nodes if no path is found
-          const sourceNode = nodeMap.get(sourceId);
-          const targetNode = nodeMap.get(targetId);
+          // For non-root connections, position at midpoint with perpendicular offset
+          labelX = source.x + dx * 0.5;
+          labelY = source.y + dy * 0.5;
           
-          if (!sourceNode || !targetNode) {
-            console.warn("Missing node in label positioning fallback");
-            return;
-          }
+          // Apply larger perpendicular offset based on hash
+          const perpOffset = 80 + (hash % 60); // 80-140px perpendicular offset
           
-          midX = (sourceNode.x + targetNode.x) / 2;
-          midY = (sourceNode.y + targetNode.y) / 2;
+          // Use a deterministic but varied sign for the offset
+          const sign = ((hash % 2) * 2 - 1); // Either 1 or -1
+          labelX += px * perpOffset * sign;
+          labelY += py * perpOffset * sign;
         }
         
-        // Store label position for overlap prevention
-        d.labelX = midX;
-        d.labelY = midY;
+        // Get text elements to calculate size
+        const textElements = labelEl.selectAll('text.link-label');
         
-        // Update transform
-        labelGroup.attr('transform', `translate(${midX}, ${midY})`);
+        if (textElements.size() > 0) {
+          let labelWidth = 0;
+          let labelHeight = 0;
+          
+          // Calculate total width and height based on all text elements
+          textElements.each(function() {
+            try {
+              const bbox = this.getBBox();
+              labelWidth = Math.max(labelWidth, bbox.width);
+              labelHeight += bbox.height;
+            } catch (e) {
+              console.log("Error getting text bounding box", e);
+            }
+          });
+          
+          // Add more padding
+          labelWidth += 30;
+          labelHeight += 16;
+          
+          // Update background rectangle size
+          labelEl.select('rect.label-bg')
+            .attr('width', labelWidth)
+            .attr('height', labelHeight)
+            .attr('x', -labelWidth / 2)
+            .attr('y', -labelHeight / 2);
+        }
         
-        // Size the background rectangle based on the text content
-        const textElements = labelGroup.selectAll('.link-label');
-        let maxWidth = 0;
-        let totalHeight = 0;
+        // Apply the transform to position the label
+        labelEl.attr('transform', `translate(${labelX}, ${labelY})`);
         
-        textElements.each(function() {
-          const bbox = this.getBBox();
-          maxWidth = Math.max(maxWidth, bbox.width);
-          totalHeight += bbox.height;
-        });
+        // Store position for collision detection
+        d.labelX = labelX;
+        d.labelY = labelY;
         
-        // Add padding to the background rectangle
-        const padding = 8;
-        
-        // Update background rectangle size with padding
-        labelGroup.select('.label-bg')
-          .attr('width', maxWidth + padding * 2)
-          .attr('height', totalHeight + padding * 2)
-          .attr('x', -maxWidth / 2 - padding)
-          .attr('y', -totalHeight / 2 - padding);
       } catch (error) {
-        console.error("Error in label positioning:", error, d);
+        console.error("Error positioning label:", error);
       }
     });
-    
-    // Run label overlap prevention
-    preventLabelOverlaps();
   } catch (error) {
-    console.error("Error in ticked function:", error);
+    console.error("Error in tick function:", error);
   }
 }
 
@@ -2357,6 +2695,43 @@ function buildGraph(subject, filterKeywords = []) {
   // Start fetch process
   const relationsZip = `../data/${subject}.zip`;
   // ... existing code ...
+}
+
+// Helper function to determine the "layer" of a node based on distance from root
+function getNodeLayer(nodeId, edgesParam) {
+  // Use provided edges parameter or fall back to global edges
+  const edgesToUse = edgesParam || window.edges;
+  
+  if (nodeId === rootSubject) {
+    return 0; // Root node is layer 0
+  }
+  
+  // Check if directly connected to root
+  const isDirectlyConnected = edgesToUse.some(
+    edge => (edge.from === rootSubject && edge.to === nodeId) || 
+            (edge.to === rootSubject && edge.from === nodeId)
+  );
+  
+  if (isDirectlyConnected) {
+    return 1; // Directly connected to root is layer 1
+  }
+  
+  // Get nodes directly connected to root
+  const connectedToRoot = edgesToUse.filter(
+    edge => edge.from === rootSubject || edge.to === rootSubject
+  ).map(edge => edge.from === rootSubject ? edge.to : edge.from);
+  
+  // Check if connected to a node that's connected to root
+  const isTwoStepsAway = edgesToUse.some(
+    edge => (connectedToRoot.includes(edge.from) && edge.to === nodeId) || 
+            (connectedToRoot.includes(edge.to) && edge.from === nodeId)
+  );
+  
+  if (isTwoStepsAway) {
+    return 2; // Two steps away from root is layer 2
+  }
+  
+  return 3; // Everything else is layer 3 or beyond
 }
 </script>
 </body>

--- a/relations/index.html
+++ b/relations/index.html
@@ -1013,6 +1013,29 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Create the graph content group
   const g = d3.select('#graph-content');
   
+  // Separate root node from other nodes
+  const rootNode = nodes.find(n => n.id === rootSubject);
+  const nonRootNodes = nodes.filter(n => n.id !== rootSubject);
+  
+  // Pre-position nodes in a structured layout
+  // Root node at center-top, other nodes in a row below
+  if (rootNode) {
+    rootNode.x = width / 2;
+    rootNode.y = height * 0.2; // Position root node at top
+    rootNode.fx = rootNode.x; // Fix position
+    rootNode.fy = rootNode.y;
+  }
+  
+  // Arrange non-root nodes in a row
+  const rowWidth = width * 0.8; // Use 80% of available width
+  const nodeSpacing = rowWidth / (nonRootNodes.length + 1);
+  
+  nonRootNodes.forEach((node, i) => {
+    node.x = (width * 0.1) + nodeSpacing * (i + 1); // Distribute evenly with margins
+    node.y = height * 0.7; // Position in a row below root
+    // Don't fix these positions completely, but use them as starting points
+  });
+  
   // Create links
   linkElements = g.append('g')
     .attr('class', 'links')
@@ -1105,12 +1128,12 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .style('cursor', 'pointer')
     .on('mouseover', function(event, d) {
       d3.select(this).attr('fill', d.color);
-      d3.select(this.parentNode).select('.link-label').attr('fill', 'white');
+      d3.select(this.parentNode).selectAll('.link-label').attr('fill', 'white');
       linkElements.filter(l => l === d).attr('stroke-width', 4);
     })
     .on('mouseout', function() {
       d3.select(this).attr('fill', '#F3F4F6');
-      d3.select(this.parentNode).select('.link-label').attr('fill', '#475569');
+      d3.select(this.parentNode).selectAll('.link-label').attr('fill', '#475569');
       linkElements.attr('stroke-width', 2);
     });
   
@@ -1167,7 +1190,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
       if (label.from === d.id || label.to === d.id) {
         d3.select(this).select('.label-bg')
           .attr('fill', label.color);
-        d3.select(this).select('.link-label')
+        d3.select(this).selectAll('.link-label')
           .attr('fill', 'white');
       }
     });
@@ -1186,11 +1209,11 @@ function renderD3Graph(rootSubject, nodes, edges) {
     // Reset label styles
     labelElements.select('.label-bg')
       .attr('fill', '#F3F4F6');
-    labelElements.select('.link-label')
+    labelElements.selectAll('.link-label')
       .attr('fill', '#475569');
   });
   
-  // Start the simulation
+  // Start the simulation with modified forces for structured layout
   simulation = d3.forceSimulation(nodes)
     .force('link', d3.forceLink(edges)
       .id(d => d.id)
@@ -1208,25 +1231,35 @@ function renderD3Graph(rootSubject, nodes, edges) {
       }))
     .force('charge', d3.forceManyBody()
       .strength(d => {
-        // Adjust repulsion based on node size
+        // Stronger repulsion for structured layout
         const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
-        return forceParams.charge * (nodeSize / 200);
+        return forceParams.charge * (nodeSize / 200) * 1.5;
       })
-      .distanceMin(150)
+      .distanceMin(200)
       .distanceMax(2000))
-    .force('center', d3.forceCenter(width / 2, height / 2))
-    .force('x', d3.forceX(width / 2).strength(0.05))
-    .force('y', d3.forceY(height / 2).strength(0.05))
+    .force('x', d3.forceX(d => {
+      // Keep root node centered, let others spread horizontally
+      if (d.id === rootSubject) return width / 2;
+      return d.x; // Use pre-positioned x value
+    }).strength(d => d.id === rootSubject ? 1 : 0.2))
+    .force('y', d3.forceY(d => {
+      // Keep root node at top, others in row below
+      if (d.id === rootSubject) return height * 0.2;
+      return height * 0.7;
+    }).strength(0.3))
     .force('collision', d3.forceCollide().radius(d => {
       // Make collision radius based on node size plus padding
       const nodeWidth = getNodeWidth(d);
       const nodeHeight = getNodeHeight(d);
-      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 50;
+      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 70; // Increased padding
     }).strength(1))
-    .alpha(0.6)
-    .alphaDecay(0.01) // Slower decay for more time to find optimal positions
-    .velocityDecay(0.4) // Lower value to allow nodes to move more freely
+    .alpha(0.8) // Higher alpha for more movement
+    .alphaDecay(0.008) // Slower decay for more time to find optimal positions
+    .velocityDecay(0.4)
     .on('tick', ticked);
+  
+  // Force an initial tick to position elements correctly
+  ticked();
   
   // Enable download button
   $('#downloadBtn').show();
@@ -1234,7 +1267,25 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Auto-zoom to fit all nodes after simulation stabilizes
   setTimeout(() => {
     zoomToFitAll();
-  }, 2000);
+    
+    // Run label overlap prevention multiple times during and after stabilization
+    preventLabelOverlaps();
+    
+    // Set up interval to repeatedly check for and fix label overlaps during simulation
+    const labelInterval = setInterval(() => {
+      preventLabelOverlaps();
+      
+      // Stop checking once simulation has cooled down
+      if (simulation.alpha() < 0.05) {
+        clearInterval(labelInterval);
+        // Final adjustment after simulation ends
+        setTimeout(() => {
+          preventLabelOverlaps();
+          ticked(); // Force one more update
+        }, 500);
+      }
+    }, 200);
+  }, 1000);
 }
 
 // Function to zoom to fit all nodes
@@ -1287,10 +1338,7 @@ function zoomToFitAll() {
     );
 }
 
-// Call the overlap prevention after the simulation has stabilized
-simulation.on('end', preventLabelOverlaps);
-
-// Update the ticked function to occasionally prevent overlaps
+// Update the ticked function to properly position labels along their paths
 function ticked() {
   // Update node positions
   nodeElements.attr('transform', d => {
@@ -1300,7 +1348,7 @@ function ticked() {
     return `translate(${d.x - getNodeWidth(d) / 2}, ${d.y - getNodeHeight(d) / 2})`;
   });
   
-  // Update link paths
+  // Update link paths with improved orthogonal routing
   linkElements.attr('d', d => {
     const sourceNode = nodeElements.filter(n => n.id === d.from).datum();
     const targetNode = nodeElements.filter(n => n.id === d.to).datum();
@@ -1333,44 +1381,77 @@ function ticked() {
     
     if (!sourcePoint || !targetPoint) return '';
     
-    // Create orthogonal (right-angled) paths
-    // Determine if the path should go horizontally first or vertically first
-    const dx = Math.abs(targetPoint.x - sourcePoint.x);
-    const dy = Math.abs(targetPoint.y - sourcePoint.y);
+    // Create orthogonal (right-angled) paths with better routing
+    // For structured layout, we want to route from top to bottom
+    // with horizontal segments as needed
     
-    // If nodes are more separated horizontally than vertically, go horizontal first
-    if (dx > dy) {
-      const midX = sourcePoint.x + (targetPoint.x - sourcePoint.x) / 2;
-      return `M${sourcePoint.x},${sourcePoint.y} 
-              L${midX},${sourcePoint.y} 
-              L${midX},${targetPoint.y} 
-              L${targetPoint.x},${targetPoint.y}`;
-    } else {
-      // Otherwise go vertical first
-      const midY = sourcePoint.y + (targetPoint.y - sourcePoint.y) / 2;
-      return `M${sourcePoint.x},${sourcePoint.y} 
-              L${sourcePoint.x},${midY} 
-              L${targetPoint.x},${midY} 
-              L${targetPoint.x},${targetPoint.y}`;
-    }
+    // Calculate midpoint Y position - place it closer to the higher node
+    const sourceIsHigher = sourcePoint.y < targetPoint.y;
+    const higherY = Math.min(sourcePoint.y, targetPoint.y);
+    const lowerY = Math.max(sourcePoint.y, targetPoint.y);
+    const yDiff = lowerY - higherY;
+    
+    // Place the horizontal segment at 1/3 of the distance from the higher node
+    const midY = higherY + yDiff * (sourceIsHigher ? 0.33 : 0.67);
+    
+    // Create the path
+    return `M${sourcePoint.x},${sourcePoint.y} 
+            L${sourcePoint.x},${midY} 
+            L${targetPoint.x},${midY} 
+            L${targetPoint.x},${targetPoint.y}`;
   });
   
-  // Update label positions with collision detection
+  // Update label positions with improved placement
   labelElements.attr('transform', function(d) {
-    const path = linkElements.filter(l => l === d).node();
+    const path = linkElements.filter(l => l.source === d.source && l.target === d.target).node();
     if (!path) return '';
     
     const pathLength = path.getTotalLength();
     if (isNaN(pathLength) || pathLength === 0) return '';
     
-    // Position label at the midpoint of the path
-    const midPoint = path.getPointAtLength(pathLength / 2);
+    // For structured layout, we want to position labels further from the source node
+    // to prevent overlapping - use positions between 60% and 80% along the path
+    // This places labels closer to the target node and away from the crowded center
     
-    // Store the midpoint for collision detection
-    d.labelX = midPoint.x;
-    d.labelY = midPoint.y;
+    // Calculate position based on source node's position in the layout
+    const sourceNode = nodeElements.filter(n => n.id === d.from).datum();
+    const targetNode = nodeElements.filter(n => n.id === d.to).datum();
     
-    return `translate(${midPoint.x}, ${midPoint.y})`;
+    if (!sourceNode || !targetNode) {
+      // Fallback to midpoint if nodes not found
+      const midPoint = path.getPointAtLength(pathLength / 2);
+      d.labelX = midPoint.x;
+      d.labelY = midPoint.y;
+      return `translate(${midPoint.x}, ${midPoint.y})`;
+    }
+    
+    // Determine if this is a connection from root to child or between other nodes
+    const rootNode = d3.select('.node.root').datum();
+    const isRootToChild = sourceNode.id === rootNode.id;
+    
+    // Position labels at different points along the path based on connection type
+    let positionRatio;
+    
+    if (isRootToChild) {
+      // For root-to-child connections, position labels at 70% along the path
+      // This places them closer to the child nodes and away from the crowded center
+      positionRatio = 0.7;
+    } else {
+      // For other connections, use a position that's 60% along the path
+      positionRatio = 0.6;
+    }
+    
+    // Get the point at the calculated position
+    const labelPoint = path.getPointAtLength(pathLength * positionRatio);
+    
+    // Store the position for collision detection
+    d.labelX = labelPoint.x;
+    d.labelY = labelPoint.y;
+    d.pathLength = pathLength;
+    d.path = path;
+    d.positionRatio = positionRatio;
+    
+    return `translate(${labelPoint.x}, ${labelPoint.y})`;
   });
   
   // Update label background sizes
@@ -1398,11 +1479,6 @@ function ticked() {
       .attr('width', maxX - minX + padding.x * 2)
       .attr('height', maxY - minY + padding.y * 2);
   });
-  
-  // Occasionally prevent label overlaps during simulation
-  if (Math.random() < 0.1) {
-    preventLabelOverlaps();
-  }
 }
 
 function dragStarted(event, d) {
@@ -1523,87 +1599,128 @@ function lineIntersection(x1, y1, x2, y2, x3, y3, x4, y4) {
   return { x, y };
 }
 
-// After positioning all labels, adjust positions to prevent overlaps
+// Improved label overlap prevention
 function preventLabelOverlaps() {
-  const labels = labelElements.nodes();
   const labelData = labelElements.data();
+  if (!labelData.length) return;
   
-  // Create a quadtree for efficient collision detection
-  const quadtree = d3.quadtree()
-    .x(d => d.labelX)
-    .y(d => d.labelY)
-    .addAll(labelData);
+  // First pass: group labels by their vertical position into rows
+  const verticalThreshold = 30;
+  const rows = [];
+  let currentRow = [];
   
-  // For each label, check for overlaps and adjust position
-  labelElements.each(function(d, i) {
-    const labelGroup = d3.select(this);
-    const labelBg = labelGroup.select('.label-bg').node();
-    if (!labelBg) return;
-    
-    const bbox = labelBg.getBBox();
-    const padding = 10; // Extra space between labels
-    
-    // Define the bounds of this label
-    const x0 = d.labelX + bbox.x - padding;
-    const y0 = d.labelY + bbox.y - padding;
-    const x1 = d.labelX + bbox.x + bbox.width + padding;
-    const y1 = d.labelY + bbox.y + bbox.height + padding;
-    
-    // Find nearby labels that might overlap
-    quadtree.visit((node, x1q, y1q, x2q, y2q) => {
-      if (!node.length) {
-        do {
-          const d2 = node.data;
-          if (d2 && d2 !== d && labelOverlap(d, d2, bbox, padding)) {
-            // Adjust position to avoid overlap
-            adjustLabelPosition(d, d2);
-          }
-        } while (node = node.next);
+  // Sort labels by y-position first
+  const sortedLabels = [...labelData].sort((a, b) => a.labelY - b.labelY);
+  
+  sortedLabels.forEach(label => {
+    if (!currentRow.length) {
+      currentRow.push(label);
+    } else {
+      const lastLabel = currentRow[currentRow.length - 1];
+      if (Math.abs(label.labelY - lastLabel.labelY) < verticalThreshold) {
+        currentRow.push(label);
+      } else {
+        rows.push([...currentRow]);
+        currentRow = [label];
       }
-      return x1q > x1 || y1q > y1 || x2q < x0 || y2q < y0;
+    }
+  });
+  
+  // Add the last row
+  if (currentRow.length) rows.push(currentRow);
+  
+  // Second pass: for each row, resolve horizontal overlaps
+  rows.forEach(row => {
+    if (row.length <= 1) return; // No overlaps with single label
+    
+    // Sort by x-position
+    row.sort((a, b) => a.labelX - b.labelX);
+    
+    // Get label widths and calculate minimum required space
+    const labelWidths = row.map(label => {
+      const labelIndex = labelData.indexOf(label);
+      const labelElement = d3.select(labelElements.nodes()[labelIndex]);
+      const labelBg = labelElement.select('.label-bg').node();
+      return labelBg ? labelBg.getBBox().width : 0;
     });
     
-    // Update the transform with the potentially adjusted position
-    labelGroup.attr('transform', `translate(${d.labelX}, ${d.labelY})`);
+    // Calculate total width and required spacing
+    const minSpacing = 30; // Increased minimum spacing between labels
+    
+    // Check for overlaps and adjust positions
+    for (let i = 0; i < row.length - 1; i++) {
+      const currentLabel = row[i];
+      const nextLabel = row[i + 1];
+      
+      const currentWidth = labelWidths[i];
+      const nextWidth = labelWidths[i + 1];
+      
+      const currentRight = currentLabel.labelX + (currentWidth / 2);
+      const nextLeft = nextLabel.labelX - (nextWidth / 2);
+      
+      // If labels overlap or are too close
+      if (nextLeft - currentRight < minSpacing) {
+        // Calculate how much we need to move
+        const moveDistance = (minSpacing - (nextLeft - currentRight)) / 2;
+        
+        // Move current label left and next label right
+        if (currentLabel.path && nextLabel.path) {
+          // Adjust position ratios to move labels apart
+          currentLabel.positionRatio = Math.max(0.4, currentLabel.positionRatio - 0.1);
+          nextLabel.positionRatio = Math.min(0.9, nextLabel.positionRatio + 0.1);
+          
+          // Update positions based on new ratios
+          const currentPoint = currentLabel.path.getPointAtLength(currentLabel.pathLength * currentLabel.positionRatio);
+          const nextPoint = nextLabel.path.getPointAtLength(nextLabel.pathLength * nextLabel.positionRatio);
+          
+          currentLabel.labelX = currentPoint.x;
+          currentLabel.labelY = currentPoint.y;
+          nextLabel.labelX = nextPoint.x;
+          nextLabel.labelY = nextPoint.y;
+          
+          // Update the DOM
+          const currentIndex = labelData.indexOf(currentLabel);
+          const nextIndex = labelData.indexOf(nextLabel);
+          
+          d3.select(labelElements.nodes()[currentIndex])
+            .attr('transform', `translate(${currentLabel.labelX}, ${currentLabel.labelY})`);
+          
+          d3.select(labelElements.nodes()[nextIndex])
+            .attr('transform', `translate(${nextLabel.labelX}, ${nextLabel.labelY})`);
+        } else {
+          // Fallback if path information is not available
+          currentLabel.labelX -= moveDistance;
+          nextLabel.labelX += moveDistance;
+          
+          const currentIndex = labelData.indexOf(currentLabel);
+          const nextIndex = labelData.indexOf(nextLabel);
+          
+          d3.select(labelElements.nodes()[currentIndex])
+            .attr('transform', `translate(${currentLabel.labelX}, ${currentLabel.labelY})`);
+          
+          d3.select(labelElements.nodes()[nextIndex])
+            .attr('transform', `translate(${nextLabel.labelX}, ${nextLabel.labelY})`);
+        }
+      }
+    }
   });
-}
-
-// Check if two labels overlap
-function labelOverlap(d1, d2, bbox, padding) {
-  // Find the index of d2 in the data array
-  const d2Index = labelElements.data().indexOf(d2);
-  const labelGroup2 = d3.select(labelElements.nodes()[d2Index]);
-  const labelBg2 = labelGroup2.select('.label-bg').node();
-  if (!labelBg2) return false;
   
-  const bbox2 = labelBg2.getBBox();
-  
-  // Check for rectangle overlap
-  return !(
-    d1.labelX + bbox.x + bbox.width + padding < d2.labelX + bbox2.x ||
-    d1.labelX + bbox.x > d2.labelX + bbox2.x + bbox2.width + padding ||
-    d1.labelY + bbox.y + bbox.height + padding < d2.labelY + bbox2.y ||
-    d1.labelY + bbox.y > d2.labelY + bbox2.y + bbox2.height + padding
-  );
-}
-
-// Adjust label position to avoid overlap
-function adjustLabelPosition(d1, d2) {
-  // Calculate vector between labels
-  const dx = d2.labelX - d1.labelX;
-  const dy = d2.labelY - d1.labelY;
-  const distance = Math.sqrt(dx * dx + dy * dy);
-  
-  if (distance < 1) {
-    // If labels are at the same position, move in a random direction
-    const angle = Math.random() * Math.PI * 2;
-    d1.labelX += Math.cos(angle) * 30;
-    d1.labelY += Math.sin(angle) * 30;
-  } else {
-    // Move away from the other label
-    const moveDistance = 30; // Distance to move
-    d1.labelX -= (dx / distance) * moveDistance;
-    d1.labelY -= (dy / distance) * moveDistance;
-  }
+  // Third pass: stagger labels vertically within rows to further reduce overlaps
+  rows.forEach(row => {
+    if (row.length <= 2) return; // No need to stagger if only 1-2 labels
+    
+    row.forEach((label, i) => {
+      // Apply a slight vertical offset based on position in row
+      // Odd indices go up, even indices go down
+      const verticalOffset = (i % 2 === 0) ? -15 : 15;
+      
+      label.labelY += verticalOffset;
+      
+      // Update the DOM
+      const labelIndex = labelData.indexOf(label);
+      d3.select(labelElements.nodes()[labelIndex])
+        .attr('transform', `translate(${label.labelX}, ${label.labelY})`);
+    });
+  });
 }
 </script>

--- a/relations/index.html
+++ b/relations/index.html
@@ -716,7 +716,7 @@ async function renderGraphForSubject(subjectName) {
       bulletInfo: subject
     };
     nodes.push(rootNode);
-    
+
     // 1) Forward edges
     for (let row of parsedRelations) {
       let s = row.subject?.trim() || "";
@@ -734,20 +734,20 @@ async function renderGraphForSubject(subjectName) {
         });
         if (hasMirror && s > o) continue;
       }
-      
+
       addNodeIfNeeded(globalNodesMap, o);
       let c = row.category?.trim() || "UNKNOWN";
       let color = categoryColors[c] || categoryColors["UNKNOWN"];
       addEdge(edgesSet, globalAllEdges, s, o, (row.label||""), c, color);
     }
-    
+
     // 2) Reverse edges
     for (let revRow of parsedRelations) {
       let s = revRow.subject?.trim() || "";
       let o = revRow.object?.trim() || "";
       if (o !== subjectName) continue;
       if (!s) continue;
-      
+
       // Skip self-loops
       if (s === o) continue;
       
@@ -763,17 +763,17 @@ async function renderGraphForSubject(subjectName) {
       let color = categoryColors[c] || categoryColors["UNKNOWN"];
       addEdge(edgesSet, globalAllEdges, s, subjectName, (revRow.label||""), c, color);
     }
-    
+
     // 3) Intergraph edges
     const potentialEdges = [];
     for (let iRow of parsedIntergraph) {
       let rp = iRow.root_person?.trim() || "";
       if (rp !== subjectName) continue;
-      
+
       let s = iRow.subject?.trim() || "";
       let o = iRow.object?.trim() || "";
       if (!s || !o) continue;
-      
+
       if (globalNodesMap.has(s) && globalNodesMap.has(o)) {
         potentialEdges.push({
           from: s,
@@ -1128,7 +1128,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Reset zoom and pan
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(width/2, height/2)
+    d3.zoomIdentity.translate(width/2, height/2).scale(0.7) // Start with a zoomed-out view
   );
   
   // Create the graph content group
@@ -1141,10 +1141,10 @@ function renderD3Graph(rootSubject, nodes, edges) {
   defs.append('marker')
     .attr('id', 'arrow')
     .attr('viewBox', '0 -5 10 10')
-    .attr('refX', 10)
+    .attr('refX', 20) // Increased to move arrow away from node
     .attr('refY', 0)
-    .attr('markerWidth', 6)
-    .attr('markerHeight', 6)
+    .attr('markerWidth', 8) // Increased size
+    .attr('markerHeight', 8) // Increased size
     .attr('orient', 'auto')
     .append('path')
     .attr('class', 'arrow-path')
@@ -1154,10 +1154,10 @@ function renderD3Graph(rootSubject, nodes, edges) {
   defs.append('marker')
     .attr('id', 'arrow-highlighted')
     .attr('viewBox', '0 -5 10 10')
-    .attr('refX', 10)
+    .attr('refX', 20) // Increased to move arrow away from node
     .attr('refY', 0)
-    .attr('markerWidth', 6)
-    .attr('markerHeight', 6)
+    .attr('markerWidth', 8) // Increased size
+    .attr('markerHeight', 8) // Increased size
     .attr('orient', 'auto')
     .append('path')
     .attr('fill', '#2563EB')
@@ -1480,11 +1480,11 @@ function renderD3Graph(rootSubject, nodes, edges) {
           const sourceSize = Math.sqrt(getNodeWidth(sourceNode) * getNodeHeight(sourceNode));
           const targetSize = Math.sqrt(getNodeWidth(targetNode) * getNodeHeight(targetNode));
           
-          // Base distance on node sizes plus padding
-          return (sourceSize + targetSize) / 2 + forceParams.linkDistance;
+          // Base distance on node sizes plus padding - increased for better spacing
+          return (sourceSize + targetSize) / 2 + forceParams.linkDistance * 1.5; // Increased distance multiplier
         } catch (error) {
           console.error("Error in link distance calculation:", error, d);
-          return forceParams.linkDistance;
+          return forceParams.linkDistance * 1.5; // Increased default distance
         }
       })
     )
@@ -1492,28 +1492,28 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .strength(d => {
         // Stronger repulsion for structured layout
         const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
-        return forceParams.charge * (nodeSize / 200) * 1.5;
+        return forceParams.charge * (nodeSize / 200) * 2.0; // Increased repulsion
       })
-      .distanceMin(200)
-      .distanceMax(2000))
+      .distanceMin(250) // Increased minimum distance
+      .distanceMax(2500)) // Increased maximum distance
     .force('x', d3.forceX(d => {
       // Keep root node centered, let others spread horizontally
       if (d.id === rootSubject) return width / 2;
       return d.x; // Use pre-positioned x value
-    }).strength(d => d.id === rootSubject ? 1 : 0.2))
+    }).strength(d => d.id === rootSubject ? 1 : 0.15)) // Reduced strength to allow more movement
     .force('y', d3.forceY(d => {
       // Keep root node at top, others in row below
       if (d.id === rootSubject) return height * 0.2;
       return height * 0.7;
-    }).strength(0.3))
+    }).strength(0.2)) // Reduced strength to allow more movement
     .force('collision', d3.forceCollide().radius(d => {
       // Make collision radius based on node size plus padding
       const nodeWidth = getNodeWidth(d);
       const nodeHeight = getNodeHeight(d);
-      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 70; // Increased padding
+      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 100; // Increased padding significantly
     }).strength(1))
     .alpha(0.8) // Higher alpha for more movement
-    .alphaDecay(0.008) // Slower decay for more time to find optimal positions
+    .alphaDecay(0.006) // Slower decay for more time to find optimal positions
     .velocityDecay(0.4)
     .on('tick', ticked);
 }
@@ -1583,20 +1583,47 @@ function ticked() {
         }
         
         // Create orthogonal (right-angled) paths with better routing
-        // Calculate midpoint Y position - place it closer to the higher node
-        const sourceIsHigher = sourcePoint.y < targetPoint.y;
-        const higherY = Math.min(sourcePoint.y, targetPoint.y);
-        const lowerY = Math.max(sourcePoint.y, targetPoint.y);
-        const yDiff = lowerY - higherY;
+        // Calculate if nodes are more horizontal or vertical to each other
+        const dx = Math.abs(targetPoint.x - sourcePoint.x);
+        const dy = Math.abs(targetPoint.y - sourcePoint.y);
+        const isHorizontal = dx > dy;
         
-        // Place the horizontal segment at 1/3 of the distance from the higher node
-        const midY = higherY + yDiff * (sourceIsHigher ? 0.33 : 0.67);
+        // Create path with more segments to avoid running behind nodes
+        let path = '';
         
-        // Create the path
-        return `M${sourcePoint.x},${sourcePoint.y} 
-                L${sourcePoint.x},${midY} 
-                L${targetPoint.x},${midY} 
-                L${targetPoint.x},${targetPoint.y}`;
+        // Add a small offset to ensure arrows don't touch nodes
+        const arrowOffset = 10;
+        
+        // Adjust target point to account for arrow
+        const targetPointWithOffset = {
+          x: targetPoint.x + (sourcePoint.x > targetPoint.x ? arrowOffset : -arrowOffset),
+          y: targetPoint.y + (sourcePoint.y > targetPoint.y ? arrowOffset : -arrowOffset)
+        };
+        
+        if (isHorizontal) {
+          // For horizontal arrangement, use 3 segments with vertical middle segment
+          const midX = (sourcePoint.x + targetPointWithOffset.x) / 2;
+          path = `M${sourcePoint.x},${sourcePoint.y} 
+                  L${midX},${sourcePoint.y} 
+                  L${midX},${targetPointWithOffset.y} 
+                  L${targetPointWithOffset.x},${targetPointWithOffset.y}`;
+        } else {
+          // For vertical arrangement, use 3 segments with horizontal middle segment
+          const midY = (sourcePoint.y + targetPointWithOffset.y) / 2;
+          path = `M${sourcePoint.x},${sourcePoint.y} 
+                  L${sourcePoint.x},${midY} 
+                  L${targetPointWithOffset.x},${midY} 
+                  L${targetPointWithOffset.x},${targetPointWithOffset.y}`;
+        }
+        
+        // Store the path points for label positioning
+        d.pathPoints = {
+          source: sourcePoint,
+          target: targetPointWithOffset,
+          isHorizontal: isHorizontal
+        };
+        
+        return path;
       } catch (error) {
         console.error("Error in link path calculation:", error, d);
         return '';
@@ -1633,6 +1660,27 @@ function ticked() {
             const midPoint = path.getPointAtLength(pathLength / 2);
             midX = midPoint.x;
             midY = midPoint.y;
+            
+            // If we have stored path points, use them for better label positioning
+            if (d.pathPoints) {
+              const { source, target, isHorizontal } = d.pathPoints;
+              
+              if (isHorizontal) {
+                // For horizontal paths, position label above or below the middle segment
+                const midX = (source.x + target.x) / 2;
+                midY = source.y + (target.y - source.y) / 2;
+                
+                // Offset the label to avoid overlapping with the path
+                midY += (source.y > target.y) ? -20 : 20;
+              } else {
+                // For vertical paths, position label to the left or right of the middle segment
+                midX = source.x + (target.x - source.x) / 2;
+                const midY = (source.y + target.y) / 2;
+                
+                // Offset the label to avoid overlapping with the path
+                midX += (source.x > target.x) ? -20 : 20;
+              }
+            }
           } else {
             // Fallback if path length is 0
             const sourceNode = nodeMap.get(sourceId);
@@ -1710,7 +1758,8 @@ function preventLabelOverlaps() {
         y: d.y - getNodeHeight(d) / 2,
         width: getNodeWidth(d),
         height: getNodeHeight(d),
-        id: d.id
+        id: d.id,
+        type: 'node'
       });
     });
     
@@ -1739,7 +1788,8 @@ function preventLabelOverlaps() {
         edge: d,
         group: labelGroup,
         originalX: labelX,
-        originalY: labelY
+        originalY: labelY,
+        type: 'label'
       });
     });
     
@@ -1748,7 +1798,7 @@ function preventLabelOverlaps() {
       const labelRect = labelRects[i];
       let hasOverlap = true;
       let attempts = 0;
-      const maxAttempts = 10;
+      const maxAttempts = 10; // Limit repositioning attempts
       
       // Try to find a position without overlaps
       while (hasOverlap && attempts < maxAttempts) {
@@ -1781,11 +1831,14 @@ function preventLabelOverlaps() {
       }
       
       // Update the label position
-      labelRect.group.attr('transform', `translate(${labelRect.x + labelRect.width/2}, ${labelRect.y + labelRect.height/2})`);
+      const newX = labelRect.x + labelRect.width/2;
+      const newY = labelRect.y + labelRect.height/2;
+      
+      labelRect.group.attr('transform', `translate(${newX}, ${newY})`);
       
       // Update stored position for future reference
-      labelRect.edge.labelX = labelRect.x + labelRect.width/2;
-      labelRect.edge.labelY = labelRect.y + labelRect.height/2;
+      labelRect.edge.labelX = newX;
+      labelRect.edge.labelY = newY;
     }
   } catch (error) {
     console.error("Error in preventLabelOverlaps:", error);
@@ -1794,11 +1847,14 @@ function preventLabelOverlaps() {
 
 // Helper function to check if two rectangles overlap
 function rectsOverlap(rect1, rect2) {
+  // Add a buffer zone to ensure labels don't touch
+  const buffer = 15;
+  
   return !(
-    rect1.x + rect1.width < rect2.x ||
-    rect2.x + rect2.width < rect1.x ||
-    rect1.y + rect1.height < rect2.y ||
-    rect2.y + rect2.height < rect1.y
+    rect1.x + rect1.width + buffer < rect2.x ||
+    rect2.x + rect2.width + buffer < rect1.x ||
+    rect1.y + rect1.height + buffer < rect2.y ||
+    rect2.y + rect2.height + buffer < rect1.y
   );
 }
 
@@ -1823,19 +1879,22 @@ function repositionLabelAwayFromRect(labelRect, overlapRect) {
   const minDistX = (labelRect.width + overlapRect.width) / 2;
   const minDistY = (labelRect.height + overlapRect.height) / 2;
   
-  // Move primarily in the direction with the least overlap
+  // Calculate the overlap amount
   const overlapX = minDistX - Math.abs(labelCenterX - rectCenterX);
   const overlapY = minDistY - Math.abs(labelCenterY - rectCenterY);
   
-  // Add a small buffer to ensure no overlap
-  const buffer = 10;
+  // Add a larger buffer to ensure no overlap
+  const buffer = 20;
+  
+  // Move in the direction with the least overlap, but with a minimum movement
+  const moveDistance = Math.max(Math.min(overlapX, overlapY) + buffer, 30);
   
   if (overlapX < overlapY) {
     // Move horizontally
-    labelRect.x += (overlapX + buffer) * Math.sign(normDirX);
+    labelRect.x += moveDistance * Math.sign(normDirX);
   } else {
     // Move vertically
-    labelRect.y += (overlapY + buffer) * Math.sign(normDirY);
+    labelRect.y += moveDistance * Math.sign(normDirY);
   }
 }
 

--- a/relations/index.html
+++ b/relations/index.html
@@ -64,12 +64,8 @@ title: People Relations (BETA)
   }
   .link {
     fill: none;
-    stroke: #CBD5E1;
     stroke-width: 2px;
     filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.05));
-  }
-  .arrow-path {
-    fill: #CBD5E1;
   }
   .label-bg {
     fill: #F3F4F6;
@@ -129,8 +125,8 @@ title: People Relations (BETA)
     fill: #94A3B8;
   }
   
-  #arrow-highlighted .arrow-path {
-    fill: #2563EB !important;
+  #arrow .arrow-path {
+    fill: #94A3B8;
   }
   
   /* Label styling */
@@ -252,12 +248,9 @@ It shows the generated graph and a legend, plus a button to go back to the searc
     <defs>
       <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
         markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-        <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-path" fill="#94A3B8" />
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#94A3B8" />
       </marker>
-      <marker id="arrow-highlighted" viewBox="0 0 10 10" refX="5" refY="5"
-        markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-        <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-path" fill="#2563EB" />
-      </marker>
+      <!-- Category-specific markers will be added dynamically by D3 -->
     </defs>
     <g id="graph-content"></g>
   </svg>
@@ -1214,28 +1207,15 @@ function renderD3Graph(rootSubject, nodes, edges) {
   defs.append('marker')
     .attr('id', 'arrow')
     .attr('viewBox', '0 -5 10 10')
-    .attr('refX', 20) // Increased to move arrow away from node
+    .attr('refX', 20)
     .attr('refY', 0)
-    .attr('markerWidth', 8) // Increased size
-    .attr('markerHeight', 8) // Increased size
+    .attr('markerWidth', 8)
+    .attr('markerHeight', 8)
     .attr('orient', 'auto')
     .append('path')
-    .attr('class', 'arrow-path')
+    .attr('fill', '#94A3B8')  // Default gray color
     .attr('d', 'M0,-5L10,0L0,5');
     
-  // Highlighted arrow marker (blue)
-  defs.append('marker')
-    .attr('id', 'arrow-highlighted')
-    .attr('viewBox', '0 -5 10 10')
-    .attr('refX', 20) // Increased to move arrow away from node
-    .attr('refY', 0)
-    .attr('markerWidth', 8) // Increased size
-    .attr('markerHeight', 8) // Increased size
-    .attr('orient', 'auto')
-    .append('path')
-    .attr('fill', '#2563EB')
-    .attr('d', 'M0,-5L10,0L0,5');
-  
   // Create a map of node IDs for quick lookup - make it global for other functions to use
   window.nodeMap = new Map();
   nodes.forEach(node => {
@@ -1473,30 +1453,42 @@ function renderD3Graph(rootSubject, nodes, edges) {
   
   // Helper function to highlight a connection between two nodes
   function highlightConnection(sourceId, targetId) {
-    // Highlight the link
-    linkElements.filter(l => {
-      return (l.from === sourceId && l.to === targetId);
-    })
-    .style('stroke', '#2563EB')
-    .style('stroke-width', '4px')
-    .attr('marker-end', 'url(#arrow-highlighted)');
+    // Find the link data to get its category color
+    const linkData = linkElements.filter(l => l.from === sourceId && l.to === targetId).data()[0];
     
-    // Highlight source and target nodes
-    nodeElements.filter(n => n.id === sourceId || n.id === targetId)
+    if (!linkData) {
+      console.warn(`No link found between ${sourceId} and ${targetId}`);
+      return;
+    }
+    
+    // Get the category color
+    const categoryColor = categoryColors[linkData.category] || categoryColors["UNKNOWN"];
+    
+    // Highlight the link with its category color
+    linkElements.filter(l => l.from === sourceId && l.to === targetId)
+      .style('stroke', categoryColor)
+      .style('stroke-width', '4px')
+      .attr('marker-end', `url(#arrow-${linkData.category || 'UNKNOWN'})`);
+    
+    // Highlight source and target nodes with the same category color
+    nodeElements.filter(n => n.id === sourceId)
       .select('rect')
-      .style('stroke', '#2563EB')
+      .style('stroke', '#2563EB')  // Source node still uses blue
+      .style('stroke-width', '3px');
+      
+    nodeElements.filter(n => n.id === targetId)
+      .select('rect')
+      .style('stroke', categoryColor)  // Target node uses category color
       .style('stroke-width', '3px');
     
-    // Highlight the label
-    labelElements.filter(l => {
-      return (l.from === sourceId && l.to === targetId);
-    })
-    .each(function() {
-      d3.select(this).select('.label-bg')
-        .style('fill', '#2563EB');
-      d3.select(this).selectAll('.link-label')
-        .style('fill', 'white');
-    });
+    // Highlight the label with the category color
+    labelElements.filter(l => l.from === sourceId && l.to === targetId)
+      .each(function() {
+        d3.select(this).select('.label-bg')
+          .style('fill', categoryColor);
+        d3.select(this).selectAll('.link-label')
+          .style('fill', 'white');
+      });
   }
   
   // Helper function to highlight all connections to/from a node
@@ -1522,12 +1514,13 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .attr('stroke', d => d.id === rootSubject ? '#2563EB' : '#94A3B8')
       .attr('stroke-width', d => d.id === rootSubject ? 3 : 1);
     
-    // Reset edge styles
+    // Reset edge styles - maintain category colors
     linkElements
       .style('stroke', null)
       .style('stroke-width', null)
       .attr('stroke', d => categoryColors[d.category] || categoryColors["UNKNOWN"])
-      .attr('stroke-width', 2);
+      .attr('stroke-width', 2)
+      .attr('marker-end', d => `url(#arrow-${d.category || 'UNKNOWN'})`);
     
     // Reset label styles
     labelElements.select('.label-bg')

--- a/relations/index.html
+++ b/relations/index.html
@@ -96,6 +96,70 @@ title: People Relations (BETA)
   .legend-item.disabled {
     opacity: 0.5;
   }
+  
+  /* Hover effects - using !important to override any inline styles */
+  .node rect:hover {
+    stroke: #2563EB !important;
+    stroke-width: 3px !important;
+  }
+  
+  .link:hover {
+    stroke: #2563EB !important;
+    stroke-width: 4px !important;
+  }
+  
+  /* Arrow styling */
+  .arrow-path {
+    fill: #94A3B8;
+  }
+  
+  #arrow-highlighted .arrow-path {
+    fill: #2563EB !important;
+  }
+  
+  /* Label styling */
+  .label-bg:hover {
+    fill: #2563EB !important;
+  }
+  
+  /* Make all text in a label group white when the background is hovered */
+  .link-label-group:hover .link-label {
+    fill: white !important;
+  }
+  
+  /* Custom data attribute selectors for connected elements */
+  .link[data-highlighted="true"] {
+    stroke: #2563EB !important;
+    stroke-width: 4px !important;
+  }
+  
+  .node rect[data-highlighted="true"] {
+    stroke: #2563EB !important;
+    stroke-width: 3px !important;
+  }
+  
+  .label-bg[data-highlighted="true"] {
+    fill: #2563EB !important;
+  }
+  
+  .link-label[data-highlighted="true"] {
+    fill: white !important;
+  }
+  
+  /* When hovering a node, highlight connected links */
+  .node:hover ~ .links .link {
+    stroke: #2563EB !important;
+    stroke-width: 4px !important;
+  }
+  
+  /* When hovering a node, highlight connected labels */
+  .node:hover ~ .label-group .link-label-group .label-bg {
+    fill: #2563EB !important;
+  }
+  
+  .node:hover ~ .label-group .link-label-group .link-label {
+    fill: white !important;
+  }
 </style>
 
 <!-- 
@@ -169,11 +233,14 @@ It shows the generated graph and a legend, plus a button to go back to the searc
 <!-- Where the graph renders -->
 <div id="graph-container" class="border rounded flex items-center justify-center bg-white">
   <svg id="graph" width="100%" height="100%">
-    <!-- Arrow marker definition for edges -->
     <defs>
       <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
         markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-        <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-path" />
+        <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-path" fill="#94A3B8" />
+      </marker>
+      <marker id="arrow-highlighted" viewBox="0 0 10 10" refX="5" refY="5"
+        markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-path" fill="#2563EB" />
       </marker>
     </defs>
     <g id="graph-content"></g>
@@ -197,6 +264,9 @@ It shows the generated graph and a legend, plus a button to go back to the searc
 let allReverseIndex = new Map();      // token -> array of lineIDs (with ranges)
 let allSubjects = [];                 // lines from subjects.csv (index = line-1)
 let allBullets = new Map();           // subject -> { bullet_point1, bullet_point2 }
+let globalSubjectsMap = new Map();    // subject name -> bullet info
+let parsedRelations = [];             // parsed relations data
+let parsedIntergraph = [];            // parsed intergraph edges data
 let searchInProgress = false;
 let searchCanceled = false;
 let hasInitialDataLoaded = false;
@@ -226,7 +296,7 @@ let labelElements = null;
 
 // We store all graph edges in memory so toggling categories is easy:
 let globalNodesMap = new Map();  // subject -> bullet info
-let globalAllEdges = [];         // all edges (including duplicates filtered out)
+let globalAllEdges = new Map();  // key -> edge object
 let globalActiveCategories = new Set(); // which categories are currently on display
 
 // Force simulation parameters
@@ -262,7 +332,12 @@ $(document).ready(async function() {
 
   // If we have ?subject=, go straight to GraphViz mode after data loads
   if (subj) {
-    renderGraphForSubject(subj);
+    try {
+      await renderGraphForSubject(subj);
+    } catch (error) {
+      console.error("Error rendering graph:", error);
+      $('#statusMessage').text(`Error: ${error.message}`);
+    }
   }
 
   // Otherwise, remain in search mode, but if the user typed any text in ?search= param, do that:
@@ -380,11 +455,73 @@ async function loadBulletsCSV(zipUrl, csvFile) {
   for (let row of parsed.data) {
     const s = row['subject']?.trim() ?? '';
     if (!s) continue;
-    allBullets.set(s, {
+    const bulletInfo = {
       bullet_point1: row['bullet_point1'] || '',
       bullet_point2: row['bullet_point2'] || ''
-    });
+    };
+    allBullets.set(s, bulletInfo);
+    globalSubjectsMap.set(s, bulletInfo);
   }
+}
+
+// Function to load relations data for a specific subject
+async function loadRelationsData(subjectName) {
+  try {
+    // figure out which partition
+    const partitionIdx = partitionIndex(subjectName);
+    let pStr = partitionIdx.toString().padStart(2,'0');
+    const relationsZip = `relations_${pStr}.zip`;
+    
+    console.log(`Loading relations data for ${subjectName} from ${relationsZip}`);
+    
+    const resp = await fetch(relationsZip);
+    if (!resp.ok) {
+      throw new Error(`Unable to fetch ${relationsZip}: ${resp.status} ${resp.statusText}`);
+    }
+    
+    const buffer = await resp.arrayBuffer();
+    const z = await JSZip.loadAsync(buffer);
+    
+    // Check if files exist in the zip
+    if (!z.file('relations.csv')) {
+      throw new Error(`Missing relations.csv in ${relationsZip}`);
+    }
+    
+    // Parse relations.csv
+    const relationsCsv = await z.file('relations.csv').async('string');
+    parsedRelations = Papa.parse(relationsCsv, { 
+      header: true, 
+      skipEmptyLines: true 
+    }).data;
+    
+    console.log(`Loaded ${parsedRelations.length} relations`);
+    
+    // Optionally load intergraph_edges.csv if it exists
+    if (z.file('intergraph_edges.csv')) {
+      const interCsv = await z.file('intergraph_edges.csv').async('string');
+      parsedIntergraph = Papa.parse(interCsv, { 
+        header: true, 
+        skipEmptyLines: true 
+      }).data;
+      console.log(`Loaded ${parsedIntergraph.length} intergraph edges`);
+    } else {
+      console.log('No intergraph_edges.csv found in zip');
+      parsedIntergraph = [];
+    }
+    
+    return true;
+  } catch (error) {
+    console.error("Error loading relations data:", error);
+    $('#statusMessage').text(`Error loading relations: ${error.message}`);
+    throw error;
+  }
+}
+
+// Helper function to determine which partition a subject belongs to
+function partitionIndex(subject) {
+  // Use murmur hash to determine partition
+  const hash = murmurHash3.x86.hash32(subject);
+  return Math.abs(hash) % NUM_PARTITIONS;
 }
 
 
@@ -547,113 +684,75 @@ $('#backToSearch').on('click', function() {
 * GRAPH MODE
 ***************************************/
 async function renderGraphForSubject(subjectName) {
-  // Show loading indicator
-  $('#loading-indicator').show();
-  $('#graph-content').empty();
-
-  // Set the search param in the URL
-  const newUrl = new URL(window.location);
-  newUrl.searchParams.set('subject', subjectName);
-  window.history.pushState({}, '', newUrl);
-
-  // Put subject name in title
-  $('#graphTitle').text(subjectName);
-
-  // Summarize from bullets.csv if found
-  let bulletInfo = allBullets.get(subjectName) || {};
-  let b1 = bulletInfo.bullet_point1 || "";
-  let b2 = bulletInfo.bullet_point2 || "";
-  let summaryHtml = `<p class="mb-2"><strong>${escapeHtml(subjectName)}</strong></p>`;
-  if (b1) summaryHtml += `<p class="mb-2">${escapeHtml(b1)}</p>`;
-  if (b2) summaryHtml += `<p>${escapeHtml(b2)}</p>`;
-  if (!b1 && !b2) {
-    summaryHtml += `<p class="text-sm text-gray-600">(No extended info available.)</p>`;
-  }
-  $('#rootSummary').html(summaryHtml);
-
-  // Clear globals for new subject
-  globalNodesMap.clear();
-  globalAllEdges = [];
-  globalActiveCategories.clear();
-
-  // Initialize D3 graph
-  initializeD3Graph();
-
-  // Add the root node
-  addNodeIfNeeded(globalNodesMap, subjectName);
-
-  // figure out which partition
-  const partitionIdx = partitionIndex(subjectName);
-  let pStr = partitionIdx.toString().padStart(2,'0');
-  const relationsZip = `relations_${pStr}.zip`;
-
   try {
-    // Show loading status
-    $('#graphInstructions').html(`
-      <div class="flex items-center gap-2">
-        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
-        <span>Loading relationship data for ${escapeHtml(subjectName)}...</span>
-      </div>
-    `);
-
-    const resp = await fetch(relationsZip);
-    if (!resp.ok) {
-      throw new Error(`Unable to fetch ${relationsZip}`);
+    // Show loading indicator
+    $('#loading-indicator').show();
+    $('#graphInstructions').hide();
+    
+    // Clear any previous error messages
+    $('#graph-container').removeClass('error');
+    
+    // Get the subject data
+    const subject = globalSubjectsMap.get(subjectName);
+    if (!subject) {
+      throw new Error(`Subject "${subjectName}" not found`);
     }
-    const buffer = await resp.arrayBuffer();
-    const z = await JSZip.loadAsync(buffer);
-
-    // Update loading status
-    $('#graphInstructions').html(`
-      <div class="flex items-center gap-2">
-        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
-        <span>Parsing relationship data...</span>
-      </div>
-    `);
-
-    // parse relations.csv, relations_reverse.csv, intergraph_edges.csv
-    const relationsCsv     = await getZipText(z, 'relations.csv');
-    const revCsv           = await getZipText(z, 'relations_reverse.csv');
-    const interCsv         = await getZipText(z, 'intergraph_edges.csv');
-
-    const parsedRelations  = Papa.parse(relationsCsv,     { header:true, skipEmptyLines:true }).data;
-    const parsedReverse    = Papa.parse(revCsv,           { header:true, skipEmptyLines:true }).data;
-    const parsedIntergraph = Papa.parse(interCsv,         { header:true, skipEmptyLines:true }).data;
-
-    // Update loading status
-    $('#graphInstructions').html(`
-      <div class="flex items-center gap-2">
-        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
-        <span>Building relationship graph...</span>
-      </div>
-    `);
-
-    let edgesSet = new Set(); // to ensure no duplicates
-
+    
+    // Load relations data for this subject
+    await loadRelationsData(subjectName);
+    
+    // Reset global variables
+    globalNodesMap = new Map();
+    globalAllEdges = new Map();
+    
+    // Create nodes and edges for the graph
+    const nodes = [];
+    const edges = [];
+    const edgesSet = new Set();
+    
+    // Add the root subject node
+    const rootNode = {
+      id: subjectName,
+      bulletInfo: subject
+    };
+    nodes.push(rootNode);
+    
     // 1) Forward edges
     for (let row of parsedRelations) {
       let s = row.subject?.trim() || "";
+      let o = row.object?.trim() || "";
       if (s !== subjectName) continue;
-      let o = (row.object || "").trim();
       if (!o) continue;
-
+      
+      // Skip self-loops
+      if (s === o) continue;
+      
+      // Check if we should skip symmetrical duplicates
+      if (parseInt(row.is_symmetrical,10)===1) {
+        let hasMirror = parsedRelations.some(rel => {
+          return (rel.subject?.trim() === o && rel.object?.trim() === s);
+        });
+        if (hasMirror && s > o) continue;
+      }
+      
       addNodeIfNeeded(globalNodesMap, o);
       let c = row.category?.trim() || "UNKNOWN";
       let color = categoryColors[c] || categoryColors["UNKNOWN"];
       addEdge(edgesSet, globalAllEdges, s, o, (row.label||""), c, color);
     }
-
+    
     // 2) Reverse edges
-    for (let revRow of parsedReverse) {
-      let obj = revRow.object?.trim() || "";
-      if (obj !== subjectName) continue;
-
+    for (let revRow of parsedRelations) {
       let s = revRow.subject?.trim() || "";
+      let o = revRow.object?.trim() || "";
+      if (o !== subjectName) continue;
       if (!s) continue;
-
-      let symmetrical = parseInt(revRow.is_symmetrical,10) === 1;
-      if (symmetrical) {
-        // skip if forward set had the mirror
+      
+      // Skip self-loops
+      if (s === o) continue;
+      
+      // Check if we should skip symmetrical duplicates
+      if (parseInt(revRow.is_symmetrical,10)===1) {
         let hasMirror = parsedRelations.some(rel => {
           return (rel.subject?.trim() === subjectName && rel.object?.trim() === s);
         });
@@ -664,17 +763,17 @@ async function renderGraphForSubject(subjectName) {
       let color = categoryColors[c] || categoryColors["UNKNOWN"];
       addEdge(edgesSet, globalAllEdges, s, subjectName, (revRow.label||""), c, color);
     }
-
+    
     // 3) Intergraph edges
     const potentialEdges = [];
     for (let iRow of parsedIntergraph) {
       let rp = iRow.root_person?.trim() || "";
       if (rp !== subjectName) continue;
-
+      
       let s = iRow.subject?.trim() || "";
       let o = iRow.object?.trim() || "";
       if (!s || !o) continue;
-
+      
       if (globalNodesMap.has(s) && globalNodesMap.has(o)) {
         potentialEdges.push({
           from: s,
@@ -697,75 +796,63 @@ async function renderGraphForSubject(subjectName) {
       }
       finalInterEdges.push(pe);
     }
-    // Add them
-    for (let pe of finalInterEdges) {
-      let c = pe.category;
-      let color = categoryColors[c] || categoryColors["UNKNOWN"];
-      addEdge(edgesSet, globalAllEdges, pe.from, pe.to, pe.label, c, color);
-    }
-
-    // Initialize active categories
-    let uniqueCats = new Set(globalAllEdges.map(e => e.category));
-    for (let c of uniqueCats) {
-      globalActiveCategories.add(c);
-    }
-
-    // Render the legend
-    renderLegend([...uniqueCats]);
-
-    // Update loading status
-    $('#graphInstructions').html(`
-      <div class="flex items-center gap-2">
-        <img src="../assets/images/loading.svg" class="loading-spinner" style="width:16px;height:16px" alt="Loading...">
-        <span>Rendering graph with ${globalNodesMap.size} nodes and ${globalAllEdges.length} connections...</span>
-      </div>
-    `);
-
-    // Prepare data for D3
-    const nodes = [];
-    const edges = [];
     
-    // Add nodes
-    for (let [subject, bulletInfo] of globalNodesMap.entries()) {
+    // Add intergraph edges
+    for (let ie of finalInterEdges) {
+      let c = ie.category;
+      let color = categoryColors[c] || categoryColors["UNKNOWN"];
+      addEdge(edgesSet, globalAllEdges, ie.from, ie.to, ie.label, c, color);
+    }
+    
+    // Convert nodes map to array
+    for (let [id, bulletInfo] of globalNodesMap) {
+      if (id === subjectName) continue; // Skip root node, already added
       nodes.push({
-        id: subject,
+        id: id,
         bulletInfo: bulletInfo
       });
     }
     
-    // Add edges
-    for (let edge of globalAllEdges) {
-      edges.push({
-        source: edge.from,
-        target: edge.to,
-        from: edge.from,
-        to: edge.to,
-        label: edge.label,
-        category: edge.category,
-        color: edge.color
-      });
+    // Convert edges set to array
+    for (let edgeKey of edgesSet) {
+      const edge = globalAllEdges.get(edgeKey);
+      if (edge) {
+        edges.push(edge);
+      }
     }
     
-    // Render the D3 graph
+    // Render the graph
     renderD3Graph(subjectName, nodes, edges);
-
-    // Restore instructions
-    setTimeout(() => {
-      $('#graphInstructions').html(`
-        Below is a visualization of our selected subject's relationships, color-coded by category.  
-        <strong>Click any color</strong> in the legend below to toggle that category on/off. The graph will re-render automatically.  
-        Click "Download SVG" to get an offline copy of the image.
-      `);
-    }, 1000);
-
-  } catch (err) {
-    console.error(err);
-    $('#graph-container').html(
-      `<div class="p-2 text-center text-sm text-red-500">Error loading relationships: ${err}</div>`
-    );
-    $('#graphInstructions').html(`
-      <div class="text-red-500">Error: ${escapeHtml(err.message)}</div>
+    
+    // Update URL with subject
+    const url = new URL(window.location);
+    url.searchParams.set('subject', subjectName);
+    window.history.pushState({}, '', url);
+    
+    // Update page title
+    document.title = `${subjectName} - People Relations`;
+    
+    // Show instructions
+    $('#graphInstructions').show();
+  } catch (error) {
+    console.error("Error loading relationships:", error);
+    
+    // Hide loading indicator
+    $('#loading-indicator').hide();
+    
+    // Display error message to user
+    $('#graph-container').html(`
+      <div class="p-4 bg-red-50 border border-red-200 rounded-md text-red-800">
+        <h3 class="font-bold mb-2">Error loading relationships:</h3>
+        <p>${error.message || error}</p>
+        <p class="mt-2">Please try refreshing the page or selecting a different subject.</p>
+      </div>
     `);
+    
+    // Update instructions
+    $('#graphInstructions').html(`
+      <p class="text-red-600">An error occurred while loading the graph. Please try again.</p>
+    `).show();
   }
 }
 
@@ -780,13 +867,21 @@ function addNodeIfNeeded(map, subject) {
 }
 
 // Deduplicate edges
-function addEdge(edgesSet, edgesArray, from, to, label, category, color) {
+function addEdge(edgesSet, edgesMap, from, to, label, category, color) {
   let key = `${from}||${to}||${category}||${label}`;
   if (edgesSet.has(key)) {
     return; // skip duplicates
   }
   edgesSet.add(key);
-  edgesArray.push({ from, to, label, category, color });
+  
+  // Store in the map with the key
+  if (!(edgesMap instanceof Map)) {
+    console.error("edgesMap is not a Map:", edgesMap);
+    // Initialize as a Map if it's not already
+    edgesMap = new Map();
+  }
+  
+  edgesMap.set(key, { from, to, label, category, color });
 }
 
 // Partition
@@ -1010,8 +1105,100 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Hide loading indicator when rendering starts
   $('#loading-indicator').hide();
   
+  // Initialize container dimensions
+  const container = document.getElementById('graph-container');
+  width = container.clientWidth;
+  height = container.clientHeight;
+  
+  // Initialize zoom behavior if not already done
+  if (!zoom) {
+    zoom = d3.zoom()
+      .scaleExtent([0.1, 2])
+      .on('zoom', (event) => {
+        d3.select('#graph-content').attr('transform', event.transform);
+      });
+    
+    // Apply zoom behavior to SVG
+    d3.select('#graph')
+      .call(zoom)
+      .on('dblclick.zoom', null); // Disable double-click zoom
+  }
+  
+  // Reset zoom and pan
+  d3.select('#graph').call(
+    zoom.transform,
+    d3.zoomIdentity.translate(width/2, height/2)
+  );
+  
   // Create the graph content group
   const g = d3.select('#graph-content');
+  
+  // Add arrow markers for links
+  const defs = g.append('defs');
+  
+  // Regular arrow marker
+  defs.append('marker')
+    .attr('id', 'arrow')
+    .attr('viewBox', '0 -5 10 10')
+    .attr('refX', 10)
+    .attr('refY', 0)
+    .attr('markerWidth', 6)
+    .attr('markerHeight', 6)
+    .attr('orient', 'auto')
+    .append('path')
+    .attr('class', 'arrow-path')
+    .attr('d', 'M0,-5L10,0L0,5');
+    
+  // Highlighted arrow marker (blue)
+  defs.append('marker')
+    .attr('id', 'arrow-highlighted')
+    .attr('viewBox', '0 -5 10 10')
+    .attr('refX', 10)
+    .attr('refY', 0)
+    .attr('markerWidth', 6)
+    .attr('markerHeight', 6)
+    .attr('orient', 'auto')
+    .append('path')
+    .attr('fill', '#2563EB')
+    .attr('d', 'M0,-5L10,0L0,5');
+  
+  // Create a map of node IDs for quick lookup - make it global for other functions to use
+  window.nodeMap = new Map();
+  nodes.forEach(node => {
+    nodeMap.set(node.id, node);
+  });
+  
+  // Preprocess edges to ensure all source and target nodes exist
+  console.log(`Processing ${edges.length} edges...`);
+  const validEdges = edges.filter(edge => {
+    const sourceId = edge.from;
+    const targetId = edge.to;
+    
+    // Check if source and target nodes exist
+    const sourceExists = nodeMap.has(sourceId);
+    const targetExists = nodeMap.has(targetId);
+    
+    if (!sourceExists) {
+      console.warn(`Edge source node not found: ${sourceId}`);
+    }
+    if (!targetExists) {
+      console.warn(`Edge target node not found: ${targetId}`);
+    }
+    
+    // Only keep edges where both nodes exist
+    if (sourceExists && targetExists) {
+      // Set source and target properties for D3
+      edge.source = sourceId;
+      edge.target = targetId;
+      return true;
+    }
+    return false;
+  });
+  
+  console.log(`Filtered to ${validEdges.length} valid edges`);
+  
+  // Store the root subject for reference in other functions
+  window.rootSubject = rootSubject;
   
   // Separate root node from other nodes
   const rootNode = nodes.find(n => n.id === rootSubject);
@@ -1040,12 +1227,29 @@ function renderD3Graph(rootSubject, nodes, edges) {
   linkElements = g.append('g')
     .attr('class', 'links')
     .selectAll('path')
-    .data(edges)
+    .data(validEdges)
     .join('path')
     .attr('class', 'link')
     .attr('stroke', d => d.color)
     .attr('stroke-width', 2)
-    .attr('marker-end', 'url(#arrow)');
+    .attr('marker-end', 'url(#arrow)')
+    .attr('data-source', d => d.from)
+    .attr('data-target', d => d.to)
+    .style('cursor', 'pointer')
+    .on('mouseover', function(event, d) {
+      console.log('Link path hover:', d);
+      
+      // Get source and target IDs
+      const sourceId = d.from;
+      const targetId = d.to;
+      
+      // Highlight this connection
+      highlightConnection(sourceId, targetId);
+    })
+    .on('mouseout', function() {
+      console.log('Link path mouseout');
+      resetHighlights();
+    });
   
   // Create nodes
   nodeElements = g.append('g')
@@ -1060,15 +1264,28 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .on('drag', dragged)
       .on('end', dragEnded)
     );
-  
+    
   // Add rectangles to nodes
   nodeElements.append('rect')
     .attr('rx', 4)
     .attr('ry', 4)
     .attr('width', d => getNodeWidth(d))
     .attr('height', d => getNodeHeight(d))
-    .style('cursor', 'grab');
-  
+    .attr('fill', 'white')
+    .attr('stroke', d => d.id === rootSubject ? '#2563EB' : '#94A3B8')
+    .attr('stroke-width', d => d.id === rootSubject ? 3 : 1)
+    .style('cursor', 'grab')
+    .on('mouseover', function(event, d) {
+      console.log('Node rect hover:', d);
+      
+      // Highlight all connections to/from this node
+      highlightNodeConnections(d.id);
+    })
+    .on('mouseout', function() {
+      console.log('Node rect mouseout');
+      resetHighlights();
+    });
+    
   // Add text to nodes
   nodeElements.each(function(d) {
     const node = d3.select(this);
@@ -1086,7 +1303,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     y += 25;
     
     // Add bullet point 1 if available
-    if (bulletInfo.bullet_point1) {
+    if (bulletInfo && bulletInfo.bullet_point1) {
       const wrappedText = wrapText(bulletInfo.bullet_point1, 30);
       wrappedText.forEach(line => {
         node.append('text')
@@ -1099,7 +1316,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     }
     
     // Add bullet point 2 if available
-    if (bulletInfo.bullet_point2) {
+    if (bulletInfo && bulletInfo.bullet_point2) {
       y += 5; // Add a little extra space
       const wrappedText = wrapText(bulletInfo.bullet_point2, 30);
       wrappedText.forEach(line => {
@@ -1112,31 +1329,38 @@ function renderD3Graph(rootSubject, nodes, edges) {
       });
     }
   });
-  
+    
   // Create edge labels
   const labelGroup = g.append('g').attr('class', 'label-group');
   labelElements = labelGroup.selectAll('g')
-    .data(edges)
+    .data(validEdges)
     .join('g')
-    .attr('class', 'link-label-group');
+    .attr('class', 'link-label-group')
+    .attr('data-source', d => d.from)
+    .attr('data-target', d => d.to);
   
   // Add background pill for labels
   labelElements.append('rect')
     .attr('rx', 12)
     .attr('ry', 12)
     .attr('class', 'label-bg')
+    .attr('fill', '#F3F4F6')
+    .attr('width', 10) // Initial size, will be updated in ticked
+    .attr('height', 10)
+    .attr('x', -5)
+    .attr('y', -5)
     .style('cursor', 'pointer')
     .on('mouseover', function(event, d) {
-      d3.select(this).attr('fill', d.color);
-      d3.select(this.parentNode).selectAll('.link-label').attr('fill', 'white');
-      linkElements.filter(l => l === d).attr('stroke-width', 4);
+      console.log('Label bg hover:', d);
+      
+      // Highlight this connection
+      highlightConnection(d.from, d.to);
     })
     .on('mouseout', function() {
-      d3.select(this).attr('fill', '#F3F4F6');
-      d3.select(this.parentNode).selectAll('.link-label').attr('fill', '#475569');
-      linkElements.attr('stroke-width', 2);
+      console.log('Label bg mouseout');
+      resetHighlights();
     });
-  
+    
   // Add text labels with wrapping
   labelElements.each(function(d) {
     const labelGroup = d3.select(this);
@@ -1146,6 +1370,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     if (!label.trim()) {
       labelGroup.append('text')
         .attr('class', 'link-label')
+        .attr('fill', '#475569')
         .text("");
       return;
     }
@@ -1157,78 +1382,107 @@ function renderD3Graph(rootSubject, nodes, edges) {
     wrappedText.forEach((line, i) => {
       labelGroup.append('text')
         .attr('class', 'link-label')
+        .attr('fill', '#475569')
+        .attr('text-anchor', 'middle') // Center text
         .attr('dy', (i - (wrappedText.length - 1) / 2) * 16)
         .text(line);
     });
   });
   
-  // Add hover effects to nodes
-  nodeElements.on('mouseover', function(event, d) {
-    // Highlight this node
-    d3.select(this).select('rect')
-      .attr('stroke-width', 3)
-      .attr('stroke', '#2563EB');
+  // Helper function to highlight a connection between two nodes
+  function highlightConnection(sourceId, targetId) {
+    // Highlight the link
+    linkElements.filter(l => {
+      return (l.from === sourceId && l.to === targetId);
+    })
+    .style('stroke', '#2563EB')
+    .style('stroke-width', '4px')
+    .attr('marker-end', 'url(#arrow-highlighted)');
     
-    // Highlight connected edges and nodes
+    // Highlight source and target nodes
+    nodeElements.filter(n => n.id === sourceId || n.id === targetId)
+      .select('rect')
+      .style('stroke', '#2563EB')
+      .style('stroke-width', '3px');
+    
+    // Highlight the label
+    labelElements.filter(l => {
+      return (l.from === sourceId && l.to === targetId);
+    })
+    .each(function() {
+      d3.select(this).select('.label-bg')
+        .style('fill', '#2563EB');
+      d3.select(this).selectAll('.link-label')
+        .style('fill', 'white');
+    });
+  }
+  
+  // Helper function to highlight all connections to/from a node
+  function highlightNodeConnections(nodeId) {
+    // Highlight all links connected to this node
     linkElements.each(function(link) {
-      if (link.from === d.id || link.to === d.id) {
-        d3.select(this)
-          .attr('stroke-width', 4)
-          .attr('stroke', link.color);
-        
-        // Highlight connected node
-        const connectedId = link.from === d.id ? link.to : link.from;
-        nodeElements.filter(n => n.id === connectedId)
-          .select('rect')
-          .attr('stroke-width', 2)
-          .attr('stroke', link.color);
+      const sourceId = link.from;
+      const targetId = link.to;
+      
+      if (sourceId === nodeId || targetId === nodeId) {
+        // Highlight this connection
+        highlightConnection(sourceId, targetId);
       }
     });
-    
-    // Highlight related labels
-    labelElements.each(function(label) {
-      if (label.from === d.id || label.to === d.id) {
-        d3.select(this).select('.label-bg')
-          .attr('fill', label.color);
-        d3.select(this).selectAll('.link-label')
-          .attr('fill', 'white');
-      }
-    });
-  })
-  .on('mouseout', function() {
+  }
+  
+  // Helper function to reset all highlights
+  function resetHighlights() {
     // Reset node styles
     nodeElements.select('rect')
-      .attr('stroke-width', d => d.id === rootSubject ? 3 : 1)
-      .attr('stroke', d => d.id === rootSubject ? '#2563EB' : '#94A3B8');
+      .style('stroke', null)
+      .style('stroke-width', null)
+      .attr('stroke', d => d.id === rootSubject ? '#2563EB' : '#94A3B8')
+      .attr('stroke-width', d => d.id === rootSubject ? 3 : 1);
     
     // Reset edge styles
     linkElements
-      .attr('stroke-width', 2)
-      .attr('stroke', d => d.color);
+      .style('stroke', null)
+      .style('stroke-width', null)
+      .attr('stroke', d => d.color)
+      .attr('stroke-width', 2);
     
     // Reset label styles
     labelElements.select('.label-bg')
+      .style('fill', null)
       .attr('fill', '#F3F4F6');
     labelElements.selectAll('.link-label')
+      .style('fill', null)
       .attr('fill', '#475569');
-  });
+  }
   
   // Start the simulation with modified forces for structured layout
   simulation = d3.forceSimulation(nodes)
-    .force('link', d3.forceLink(edges)
+    .force('link', d3.forceLink()
+      .links(validEdges)
       .id(d => d.id)
       .distance(d => {
-        // Adjust link distance based on node sizes
-        const sourceNode = nodes.find(n => n.id === d.from);
-        const targetNode = nodes.find(n => n.id === d.to);
-        if (!sourceNode || !targetNode) return forceParams.linkDistance;
-        
-        const sourceSize = Math.sqrt(getNodeWidth(sourceNode) * getNodeHeight(sourceNode));
-        const targetSize = Math.sqrt(getNodeWidth(targetNode) * getNodeHeight(targetNode));
-        
-        // Base distance on node sizes plus padding
-        return (sourceSize + targetSize) / 2 + forceParams.linkDistance;
-      }))
+        try {
+          // Get source and target nodes
+          const sourceNode = d.source;
+          const targetNode = d.target;
+          
+          if (!sourceNode || !targetNode) {
+            console.warn("Missing node in link distance calculation");
+            return forceParams.linkDistance;
+          }
+          
+          const sourceSize = Math.sqrt(getNodeWidth(sourceNode) * getNodeHeight(sourceNode));
+          const targetSize = Math.sqrt(getNodeWidth(targetNode) * getNodeHeight(targetNode));
+          
+          // Base distance on node sizes plus padding
+          return (sourceSize + targetSize) / 2 + forceParams.linkDistance;
+        } catch (error) {
+          console.error("Error in link distance calculation:", error, d);
+          return forceParams.linkDistance;
+        }
+      })
+    )
     .force('charge', d3.forceManyBody()
       .strength(d => {
         // Stronger repulsion for structured layout
@@ -1257,280 +1511,484 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .alphaDecay(0.008) // Slower decay for more time to find optimal positions
     .velocityDecay(0.4)
     .on('tick', ticked);
-  
-  // Force an initial tick to position elements correctly
-  ticked();
-  
-  // Enable download button
-  $('#downloadBtn').show();
-  
-  // Auto-zoom to fit all nodes after simulation stabilizes
-  setTimeout(() => {
-    zoomToFitAll();
-    
-    // Run label overlap prevention multiple times during and after stabilization
-    preventLabelOverlaps();
-    
-    // Set up interval to repeatedly check for and fix label overlaps during simulation
-    const labelInterval = setInterval(() => {
-      preventLabelOverlaps();
-      
-      // Stop checking once simulation has cooled down
-      if (simulation.alpha() < 0.05) {
-        clearInterval(labelInterval);
-        // Final adjustment after simulation ends
-        setTimeout(() => {
-          preventLabelOverlaps();
-          ticked(); // Force one more update
-        }, 500);
-      }
-    }, 200);
-  }, 1000);
 }
 
-// Function to zoom to fit all nodes
-function zoomToFitAll() {
-  if (!nodeElements || !nodeElements.size()) return;
-  
-  // Get bounding box of all nodes
-  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-  
-  nodeElements.each(function(d) {
-    const nodeWidth = getNodeWidth(d);
-    const nodeHeight = getNodeHeight(d);
-    
-    minX = Math.min(minX, d.x - nodeWidth/2);
-    minY = Math.min(minY, d.y - nodeHeight/2);
-    maxX = Math.max(maxX, d.x + nodeWidth/2);
-    maxY = Math.max(maxY, d.y + nodeHeight/2);
-  });
-  
-  // Add padding
-  const padding = 50;
-  minX -= padding;
-  minY -= padding;
-  maxX += padding;
-  maxY += padding;
-  
-  const graphWidth = maxX - minX;
-  const graphHeight = maxY - minY;
-  
-  // Calculate scale to fit
-  const scale = Math.min(
-    width / graphWidth,
-    height / graphHeight,
-    1.5 // Max scale
-  );
-  
-  // Calculate center point
-  const centerX = minX + graphWidth/2;
-  const centerY = minY + graphHeight/2;
-  
-  // Apply zoom transform
-  d3.select('#graph').transition()
-    .duration(750)
-    .call(
-      zoom.transform,
-      d3.zoomIdentity
-        .translate(width/2, height/2)
-        .scale(scale)
-        .translate(-centerX, -centerY)
-    );
-}
-
-// Update the ticked function to properly position labels along their paths
+// Update the ticked function to properly position nodes, links, and labels
 function ticked() {
-  // Update node positions
-  nodeElements.attr('transform', d => {
-    // Constrain to bounds
-    d.x = Math.max(forceParams.bounds.left, Math.min(width - forceParams.bounds.right, d.x));
-    d.y = Math.max(forceParams.bounds.top, Math.min(height - forceParams.bounds.bottom, d.y));
-    return `translate(${d.x - getNodeWidth(d) / 2}, ${d.y - getNodeHeight(d) / 2})`;
-  });
-  
-  // Update link paths with improved orthogonal routing
-  linkElements.attr('d', d => {
-    const sourceNode = nodeElements.filter(n => n.id === d.from).datum();
-    const targetNode = nodeElements.filter(n => n.id === d.to).datum();
-    
-    if (!sourceNode || !targetNode) return '';
-    
-    const sourceWidth = getNodeWidth(sourceNode);
-    const sourceHeight = getNodeHeight(sourceNode);
-    const targetWidth = getNodeWidth(targetNode);
-    const targetHeight = getNodeHeight(targetNode);
-    
-    // Calculate source and target points on the edges of the rectangles
-    const sourceX = sourceNode.x;
-    const sourceY = sourceNode.y;
-    const targetX = targetNode.x;
-    const targetY = targetNode.y;
-    
-    // Find intersection points with rectangles
-    const sourcePoint = findIntersectionPoint(
-      sourceX, sourceY, targetX, targetY,
-      sourceX - sourceWidth/2, sourceY - sourceHeight/2,
-      sourceWidth, sourceHeight
-    );
-    
-    const targetPoint = findIntersectionPoint(
-      targetX, targetY, sourceX, sourceY,
-      targetX - targetWidth/2, targetY - targetHeight/2,
-      targetWidth, targetHeight
-    );
-    
-    if (!sourcePoint || !targetPoint) return '';
-    
-    // Create orthogonal (right-angled) paths with better routing
-    // For structured layout, we want to route from top to bottom
-    // with horizontal segments as needed
-    
-    // Calculate midpoint Y position - place it closer to the higher node
-    const sourceIsHigher = sourcePoint.y < targetPoint.y;
-    const higherY = Math.min(sourcePoint.y, targetPoint.y);
-    const lowerY = Math.max(sourcePoint.y, targetPoint.y);
-    const yDiff = lowerY - higherY;
-    
-    // Place the horizontal segment at 1/3 of the distance from the higher node
-    const midY = higherY + yDiff * (sourceIsHigher ? 0.33 : 0.67);
-    
-    // Create the path
-    return `M${sourcePoint.x},${sourcePoint.y} 
-            L${sourcePoint.x},${midY} 
-            L${targetPoint.x},${midY} 
-            L${targetPoint.x},${targetPoint.y}`;
-  });
-  
-  // Update label positions with improved placement
-  labelElements.attr('transform', function(d) {
-    const path = linkElements.filter(l => l.source === d.source && l.target === d.target).node();
-    if (!path) return '';
-    
-    const pathLength = path.getTotalLength();
-    if (isNaN(pathLength) || pathLength === 0) return '';
-    
-    // For structured layout, we want to position labels further from the source node
-    // to prevent overlapping - use positions between 60% and 80% along the path
-    // This places labels closer to the target node and away from the crowded center
-    
-    // Calculate position based on source node's position in the layout
-    const sourceNode = nodeElements.filter(n => n.id === d.from).datum();
-    const targetNode = nodeElements.filter(n => n.id === d.to).datum();
-    
-    if (!sourceNode || !targetNode) {
-      // Fallback to midpoint if nodes not found
-      const midPoint = path.getPointAtLength(pathLength / 2);
-      d.labelX = midPoint.x;
-      d.labelY = midPoint.y;
-      return `translate(${midPoint.x}, ${midPoint.y})`;
-    }
-    
-    // Determine if this is a connection from root to child or between other nodes
-    const rootNode = d3.select('.node.root').datum();
-    const isRootToChild = sourceNode.id === rootNode.id;
-    
-    // Position labels at different points along the path based on connection type
-    let positionRatio;
-    
-    if (isRootToChild) {
-      // For root-to-child connections, position labels at 70% along the path
-      // This places them closer to the child nodes and away from the crowded center
-      positionRatio = 0.7;
-    } else {
-      // For other connections, use a position that's 60% along the path
-      positionRatio = 0.6;
-    }
-    
-    // Get the point at the calculated position
-    const labelPoint = path.getPointAtLength(pathLength * positionRatio);
-    
-    // Store the position for collision detection
-    d.labelX = labelPoint.x;
-    d.labelY = labelPoint.y;
-    d.pathLength = pathLength;
-    d.path = path;
-    d.positionRatio = positionRatio;
-    
-    return `translate(${labelPoint.x}, ${labelPoint.y})`;
-  });
-  
-  // Update label background sizes
-  labelElements.each(function(d) {
-    const labelTexts = d3.select(this).selectAll('.link-label');
-    if (!labelTexts.size()) return;
-    
-    // Calculate bounding box that encompasses all text elements
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-    
-    labelTexts.each(function() {
-      const bbox = this.getBBox();
-      minX = Math.min(minX, bbox.x);
-      minY = Math.min(minY, bbox.y);
-      maxX = Math.max(maxX, bbox.x + bbox.width);
-      maxY = Math.max(maxY, bbox.y + bbox.height);
+  try {
+    // Update node positions
+    nodeElements.attr('transform', d => {
+      // Constrain to bounds
+      d.x = Math.max(50, Math.min(width - 50, d.x));
+      d.y = Math.max(50, Math.min(height - 50, d.y));
+      return `translate(${d.x - getNodeWidth(d) / 2}, ${d.y - getNodeHeight(d) / 2})`;
     });
     
-    // Add padding
-    const padding = { x: 10, y: 6 };
+    // Update link paths with improved orthogonal routing
+    linkElements.attr('d', d => {
+      try {
+        // Get source and target IDs
+        const sourceId = d.from;
+        const targetId = d.to;
+        
+        if (!sourceId || !targetId) {
+          console.warn("Missing source or target ID in link path calculation:", d);
+          return '';
+        }
+        
+        // Get the actual node objects using the nodeMap
+        const sourceNode = nodeMap.get(sourceId);
+        const targetNode = nodeMap.get(targetId);
+        
+        if (!sourceNode || !targetNode) {
+          console.warn("Missing node for link in ticked:", 
+                      !sourceNode ? `source: ${sourceId}` : `target: ${targetId}`);
+          return '';
+        }
+        
+        // Calculate dimensions
+        const sourceWidth = getNodeWidth(sourceNode);
+        const sourceHeight = getNodeHeight(sourceNode);
+        const targetWidth = getNodeWidth(targetNode);
+        const targetHeight = getNodeHeight(targetNode);
+        
+        // Calculate source and target centers
+        const sourceX = sourceNode.x;
+        const sourceY = sourceNode.y;
+        const targetX = targetNode.x;
+        const targetY = targetNode.y;
+        
+        // Find intersection points with rectangles
+        const sourcePoint = findIntersectionPoint(
+          sourceX, sourceY, targetX, targetY,
+          sourceX - sourceWidth/2, sourceY - sourceHeight/2,
+          sourceWidth, sourceHeight
+        );
+        
+        const targetPoint = findIntersectionPoint(
+          targetX, targetY, sourceX, sourceY,
+          targetX - targetWidth/2, targetY - targetHeight/2,
+          targetWidth, targetHeight
+        );
+        
+        if (!sourcePoint || !targetPoint) {
+          console.warn("Could not find intersection points for link:", sourceId, targetId);
+          // Fallback to direct line between centers
+          return `M${sourceX},${sourceY} L${targetX},${targetY}`;
+        }
+        
+        // Create orthogonal (right-angled) paths with better routing
+        // Calculate midpoint Y position - place it closer to the higher node
+        const sourceIsHigher = sourcePoint.y < targetPoint.y;
+        const higherY = Math.min(sourcePoint.y, targetPoint.y);
+        const lowerY = Math.max(sourcePoint.y, targetPoint.y);
+        const yDiff = lowerY - higherY;
+        
+        // Place the horizontal segment at 1/3 of the distance from the higher node
+        const midY = higherY + yDiff * (sourceIsHigher ? 0.33 : 0.67);
+        
+        // Create the path
+        return `M${sourcePoint.x},${sourcePoint.y} 
+                L${sourcePoint.x},${midY} 
+                L${targetPoint.x},${midY} 
+                L${targetPoint.x},${targetPoint.y}`;
+      } catch (error) {
+        console.error("Error in link path calculation:", error, d);
+        return '';
+      }
+    });
     
-    d3.select(this).select('.label-bg')
-      .attr('x', minX - padding.x)
-      .attr('y', minY - padding.y)
-      .attr('width', maxX - minX + padding.x * 2)
-      .attr('height', maxY - minY + padding.y * 2);
-  });
+    // Update label positions
+    labelElements.each(function(d) {
+      try {
+        const labelGroup = d3.select(this);
+        
+        // Get source and target IDs
+        const sourceId = d.from;
+        const targetId = d.to;
+        
+        if (!sourceId || !targetId) {
+          console.warn("Missing source or target ID in label positioning");
+          return;
+        }
+        
+        // Find the path element for this edge
+        const path = d3.select(`path.link[data-source="${sourceId}"][data-target="${targetId}"]`).node();
+        
+        let midX, midY;
+        
+        // If we have a path, position the label at its midpoint
+        if (path) {
+          const pathLength = path.getTotalLength();
+          if (pathLength) {
+            // Store the path for later use in overlap prevention
+            d.path = path;
+            
+            // Get the midpoint of the path
+            const midPoint = path.getPointAtLength(pathLength / 2);
+            midX = midPoint.x;
+            midY = midPoint.y;
+          } else {
+            // Fallback if path length is 0
+            const sourceNode = nodeMap.get(sourceId);
+            const targetNode = nodeMap.get(targetId);
+            
+            if (!sourceNode || !targetNode) {
+              console.warn("Missing node in label positioning fallback");
+              return;
+            }
+            
+            midX = (sourceNode.x + targetNode.x) / 2;
+            midY = (sourceNode.y + targetNode.y) / 2;
+          }
+        } else {
+          // Fallback: position between nodes if no path is found
+          const sourceNode = nodeMap.get(sourceId);
+          const targetNode = nodeMap.get(targetId);
+          
+          if (!sourceNode || !targetNode) {
+            console.warn("Missing node in label positioning fallback");
+            return;
+          }
+          
+          midX = (sourceNode.x + targetNode.x) / 2;
+          midY = (sourceNode.y + targetNode.y) / 2;
+        }
+        
+        // Store label position for overlap prevention
+        d.labelX = midX;
+        d.labelY = midY;
+        
+        // Update transform
+        labelGroup.attr('transform', `translate(${midX}, ${midY})`);
+        
+        // Size the background rectangle based on the text content
+        const textElements = labelGroup.selectAll('.link-label');
+        let maxWidth = 0;
+        let totalHeight = 0;
+        
+        textElements.each(function() {
+          const bbox = this.getBBox();
+          maxWidth = Math.max(maxWidth, bbox.width);
+          totalHeight += bbox.height;
+        });
+        
+        // Add padding to the background rectangle
+        const padding = 8;
+        
+        // Update background rectangle size with padding
+        labelGroup.select('.label-bg')
+          .attr('width', maxWidth + padding * 2)
+          .attr('height', totalHeight + padding * 2)
+          .attr('x', -maxWidth / 2 - padding)
+          .attr('y', -totalHeight / 2 - padding);
+      } catch (error) {
+        console.error("Error in label positioning:", error, d);
+      }
+    });
+    
+    // Run label overlap prevention
+    preventLabelOverlaps();
+  } catch (error) {
+    console.error("Error in ticked function:", error);
+  }
 }
 
-function dragStarted(event, d) {
-  if (!event.active) simulation.alphaTarget(0.3).restart();
-  d.fx = d.x;
-  d.fy = d.y;
-  d3.select(this).style('cursor', 'grabbing');
+// Function to prevent label overlaps with nodes
+function preventLabelOverlaps() {
+  try {
+    // For each label, check if it overlaps with any node
+    labelElements.each(function(d) {
+      try {
+        const labelGroup = d3.select(this);
+        const labelBg = labelGroup.select('.label-bg');
+        
+        // Skip if no background element
+        if (labelBg.empty()) return;
+        
+        // Get the label's bounding box
+        const labelBBox = labelBg.node().getBBox();
+        if (!labelBBox) return;
+        
+        // Current label position
+        const labelX = d.labelX || 0;
+        const labelY = d.labelY || 0;
+        
+        // Create a rectangle representing the label's current position
+        const labelRect = {
+          x: labelX - labelBBox.width / 2,
+          y: labelY - labelBBox.height / 2,
+          width: labelBBox.width,
+          height: labelBBox.height
+        };
+        
+        // Check for overlaps with nodes
+        let maxOverlap = 0;
+        nodeElements.each(function(nodeData) {
+          const nodeRect = {
+            x: nodeData.x - getNodeWidth(nodeData) / 2,
+            y: nodeData.y - getNodeHeight(nodeData) / 2,
+            width: getNodeWidth(nodeData),
+            height: getNodeHeight(nodeData)
+          };
+          
+          // Calculate overlap area
+          const overlapArea = calculateOverlapArea(labelRect, nodeRect);
+          maxOverlap = Math.max(maxOverlap, overlapArea);
+        });
+        
+        // If there's significant overlap, try to reposition the label
+        if (maxOverlap > 0) {
+          // Get source and target IDs
+          const sourceId = d.from;
+          const targetId = d.to;
+          
+          if (!sourceId || !targetId) return;
+          
+          // Find the path for this label
+          let path = d.path;
+          
+          // If path is not stored, try to find it
+          if (!path) {
+            path = d3.select(`path[data-source="${sourceId}"][data-target="${targetId}"]`).node();
+            if (!path) {
+              console.log('No path found for label:', sourceId, targetId);
+              return;
+            }
+            d.path = path;
+          }
+          
+          const pathLength = path.getTotalLength();
+          if (!pathLength || pathLength <= 0) {
+            console.log('Invalid path length:', pathLength);
+            return;
+          }
+          
+          // Try different positions along the path
+          let bestPosition = 0.5; // Default to midpoint
+          let minOverlap = maxOverlap;
+          
+          // Test positions at 5% increments
+          for (let pos = 0.05; pos <= 0.95; pos += 0.05) {
+            if (pos === 0.5) continue; // Skip the current position
+            
+            const testPoint = path.getPointAtLength(pathLength * pos);
+            
+            // Create a rectangle for this test position
+            const testRect = {
+              x: testPoint.x - labelBBox.width / 2,
+              y: testPoint.y - labelBBox.height / 2,
+              width: labelBBox.width,
+              height: labelBBox.height
+            };
+            
+            // Check overlap with all nodes
+            let testMaxOverlap = 0;
+            nodeElements.each(function(nodeData) {
+              const nodeRect = {
+                x: nodeData.x - getNodeWidth(nodeData) / 2,
+                y: nodeData.y - getNodeHeight(nodeData) / 2,
+                width: getNodeWidth(nodeData),
+                height: getNodeHeight(nodeData)
+              };
+              
+              const overlapArea = calculateOverlapArea(testRect, nodeRect);
+              testMaxOverlap = Math.max(testMaxOverlap, overlapArea);
+            });
+            
+            // If this position has less overlap, use it
+            if (testMaxOverlap < minOverlap) {
+              minOverlap = testMaxOverlap;
+              bestPosition = pos;
+            }
+          }
+          
+          // If we found a better position, update the label
+          if (bestPosition !== 0.5) {
+            const newPoint = path.getPointAtLength(pathLength * bestPosition);
+            
+            // Update stored position
+            d.labelX = newPoint.x;
+            d.labelY = newPoint.y;
+            
+            // Update transform
+            labelGroup.attr('transform', `translate(${newPoint.x}, ${newPoint.y})`);
+            
+            console.log('Repositioned label to reduce overlap:', sourceId, targetId, bestPosition);
+          }
+        }
+      } catch (error) {
+        console.error("Error in label overlap prevention for label:", error, d);
+      }
+    });
+  } catch (error) {
+    console.error("Error in preventLabelOverlaps:", error);
+  }
 }
 
-function dragged(event, d) {
-  d.fx = event.x;
-  d.fy = event.y;
-}
-
-function dragEnded(event, d) {
-  if (!event.active) simulation.alphaTarget(0);
-  d.fx = null;
-  d.fy = null;
-  d3.select(this).style('cursor', 'grab');
-}
-
-function getNodeWidth(d) {
-  // Calculate width based on text content
-  const minWidth = 200;
-  const textLength = d.id.length;
-  const bulletLength1 = d.bulletInfo?.bullet_point1?.length || 0;
-  const bulletLength2 = d.bulletInfo?.bullet_point2?.length || 0;
-  const maxTextLength = Math.max(textLength, bulletLength1 / 5, bulletLength2 / 5);
-  return Math.max(minWidth, maxTextLength * 7);
-}
-
-function getNodeHeight(d) {
-  // Calculate height based on text content
-  const baseHeight = 50; // Minimum height
-  const bulletInfo = d.bulletInfo;
-  let additionalHeight = 0;
+// Helper function to calculate the overlap area between two rectangles
+function calculateOverlapArea(rect1, rect2) {
+  // Calculate the overlap along the x-axis
+  const overlapX = Math.max(0, 
+    Math.min(rect1.x + rect1.width, rect2.x + rect2.width) - 
+    Math.max(rect1.x, rect2.x)
+  );
   
-  if (bulletInfo.bullet_point1) {
-    const lines1 = Math.ceil(bulletInfo.bullet_point1.length / 30);
-    additionalHeight += lines1 * 18;
+  // Calculate the overlap along the y-axis
+  const overlapY = Math.max(0, 
+    Math.min(rect1.y + rect1.height, rect2.y + rect2.height) - 
+    Math.max(rect1.y, rect2.y)
+  );
+  
+  // The overlap area is the product of the x and y overlaps
+  return overlapX * overlapY;
+}
+
+// Helper function to find intersection point of a line with a rectangle
+function findIntersectionPoint(x1, y1, x2, y2, rectX, rectY, rectWidth, rectHeight) {
+  // Line equation: y = mx + b
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  
+  // Handle vertical line
+  if (Math.abs(dx) < 0.001) {
+    // Check if the line intersects the top or bottom of the rectangle
+    if (x1 >= rectX && x1 <= rectX + rectWidth) {
+      if (y1 < y2) { // Line going down
+        return { x: x1, y: rectY };
+      } else { // Line going up
+        return { x: x1, y: rectY + rectHeight };
+      }
+    }
+    return null;
   }
   
-  if (bulletInfo.bullet_point2) {
-    const lines2 = Math.ceil(bulletInfo.bullet_point2.length / 30);
-    additionalHeight += lines2 * 18 + 5; // +5 for spacing
+  // Handle horizontal line
+  if (Math.abs(dy) < 0.001) {
+    // Check if the line intersects the left or right of the rectangle
+    if (y1 >= rectY && y1 <= rectY + rectHeight) {
+      if (x1 < x2) { // Line going right
+        return { x: rectX + rectWidth, y: y1 };
+      } else { // Line going left
+        return { x: rectX, y: y1 };
+      }
+    }
+    return null;
   }
   
-  return baseHeight + additionalHeight;
+  // Calculate slope and y-intercept
+  const m = dy / dx;
+  const b = y1 - m * x1;
+  
+  // Check intersection with each edge of the rectangle
+  const intersections = [];
+  
+  // Top edge: y = rectY
+  const topX = (rectY - b) / m;
+  if (topX >= rectX && topX <= rectX + rectWidth) {
+    intersections.push({ x: topX, y: rectY, dist: Math.hypot(topX - x1, rectY - y1) });
+  }
+  
+  // Bottom edge: y = rectY + rectHeight
+  const bottomX = (rectY + rectHeight - b) / m;
+  if (bottomX >= rectX && bottomX <= rectX + rectWidth) {
+    intersections.push({ x: bottomX, y: rectY + rectHeight, dist: Math.hypot(bottomX - x1, rectY + rectHeight - y1) });
+  }
+  
+  // Left edge: x = rectX
+  const leftY = m * rectX + b;
+  if (leftY >= rectY && leftY <= rectY + rectHeight) {
+    intersections.push({ x: rectX, y: leftY, dist: Math.hypot(rectX - x1, leftY - y1) });
+  }
+  
+  // Right edge: x = rectX + rectWidth
+  const rightY = m * (rectX + rectWidth) + b;
+  if (rightY >= rectY && rightY <= rectY + rectHeight) {
+    intersections.push({ x: rectX + rectWidth, y: rightY, dist: Math.hypot(rectX + rectWidth - x1, rightY - y1) });
+  }
+  
+  // Find the closest intersection point in the direction of the line
+  let closestPoint = null;
+  let minDist = Infinity;
+  
+  for (const point of intersections) {
+    // Check if the point is in the direction of the line
+    const dotProduct = (point.x - x1) * (x2 - x1) + (point.y - y1) * (y2 - y1);
+    if (dotProduct > 0) {
+      if (point.dist < minDist) {
+        minDist = point.dist;
+        closestPoint = point;
+      }
+    }
+  }
+  
+  return closestPoint;
 }
 
-function wrapText(text, maxCharsPerLine) {
-  if (!text) return [];
+// Helper function to get node width
+function getNodeWidth(node) {
+  // Default width if not calculated yet
+  if (!node._width) {
+    // Base width on text length
+    const textLength = node.id ? node.id.length : 10;
+    const bulletInfo = node.bulletInfo || {};
+    const bullet1 = bulletInfo.bullet_point1 || '';
+    const bullet2 = bulletInfo.bullet_point2 || '';
+    
+    // Find the longest line after wrapping
+    const wrappedBullet1 = wrapText(bullet1, 30);
+    const wrappedBullet2 = wrapText(bullet2, 30);
+    
+    let maxLineLength = textLength;
+    wrappedBullet1.forEach(line => {
+      maxLineLength = Math.max(maxLineLength, line.length);
+    });
+    wrappedBullet2.forEach(line => {
+      maxLineLength = Math.max(maxLineLength, line.length);
+    });
+    
+    // Calculate width based on the longest text
+    node._width = Math.max(
+      Math.min(maxLineLength * 8, 350),
+      150
+    );
+  }
+  return node._width;
+}
+
+// Helper function to get node height
+function getNodeHeight(node) {
+  // Default height if not calculated yet
+  if (!node._height) {
+    // Base height on number of text lines
+    const bulletInfo = node.bulletInfo || {};
+    const bullet1 = bulletInfo.bullet_point1 || '';
+    const bullet2 = bulletInfo.bullet_point2 || '';
+    
+    // Count lines after wrapping
+    const wrappedBullet1 = wrapText(bullet1, 30);
+    const wrappedBullet2 = wrapText(bullet2, 30);
+    
+    const bulletLines1 = wrappedBullet1.length;
+    const bulletLines2 = wrappedBullet2.length;
+    
+    // Calculate height based on number of lines
+    node._height = 30 + (bulletLines1 + bulletLines2) * 18;
+    
+    // Add extra padding if there are two bullet points
+    if (bulletLines1 > 0 && bulletLines2 > 0) {
+      node._height += 10;
+    }
+    
+    // Ensure minimum height
+    node._height = Math.max(node._height, 60);
+  }
+  return node._height;
+}
+
+// Helper function to wrap text to a specified width
+function wrapText(text, maxChars) {
+  if (!text) return [''];
   
   const words = text.split(' ');
   const lines = [];
@@ -1538,7 +1996,7 @@ function wrapText(text, maxCharsPerLine) {
   
   words.forEach(word => {
     const testLine = currentLine ? `${currentLine} ${word}` : word;
-    if (testLine.length <= maxCharsPerLine) {
+    if (testLine.length <= maxChars) {
       currentLine = testLine;
     } else {
       lines.push(currentLine);
@@ -1553,174 +2011,65 @@ function wrapText(text, maxCharsPerLine) {
   return lines;
 }
 
-function findIntersectionPoint(x1, y1, x2, y2, rectX, rectY, rectWidth, rectHeight) {
-  // Calculate rectangle corners
-  const corners = [
-    { x: rectX, y: rectY }, // top-left
-    { x: rectX + rectWidth, y: rectY }, // top-right
-    { x: rectX + rectWidth, y: rectY + rectHeight }, // bottom-right
-    { x: rectX, y: rectY + rectHeight } // bottom-left
-  ];
-  
-  // Check intersection with each edge of the rectangle
-  const edges = [
-    [corners[0], corners[1]], // top
-    [corners[1], corners[2]], // right
-    [corners[2], corners[3]], // bottom
-    [corners[3], corners[0]]  // left
-  ];
-  
-  for (const [p1, p2] of edges) {
-    const intersection = lineIntersection(x1, y1, x2, y2, p1.x, p1.y, p2.x, p2.y);
-    if (intersection) {
-      return intersection;
-    }
+// Drag functions for nodes
+function dragStarted(event, d) {
+  if (!event.active) simulation.alphaTarget(0.3).restart();
+  d.fx = d.x;
+  d.fy = d.y;
+  d3.select(this).select('rect').style('cursor', 'grabbing');
+}
+
+function dragged(event, d) {
+  d.fx = event.x;
+  d.fy = event.y;
+}
+
+function dragEnded(event, d) {
+  if (!event.active) simulation.alphaTarget(0);
+  // Keep root node fixed, release others
+  if (d.id !== rootSubject) {
+    d.fx = null;
+    d.fy = null;
   }
-  
-  // If no intersection found, return center of rectangle
-  return { x: rectX + rectWidth / 2, y: rectY + rectHeight / 2 };
+  d3.select(this).select('rect').style('cursor', 'grab');
 }
 
-function lineIntersection(x1, y1, x2, y2, x3, y3, x4, y4) {
-  // Calculate determinants
-  const den = (y4 - y3) * (x2 - x1) - (x4 - x3) * (y2 - y1);
-  if (den === 0) return null; // Lines are parallel
+// Function to zoom to fit all nodes
+function zoomToFitAll() {
+  // Get the bounds of all nodes
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
   
-  const ua = ((x4 - x3) * (y1 - y3) - (y4 - y3) * (x1 - x3)) / den;
-  const ub = ((x2 - x1) * (y1 - y3) - (y2 - y1) * (x1 - x3)) / den;
-  
-  // Check if intersection is on both line segments
-  if (ua < 0 || ua > 1 || ub < 0 || ub > 1) return null;
-  
-  // Calculate intersection point
-  const x = x1 + ua * (x2 - x1);
-  const y = y1 + ua * (y2 - y1);
-  
-  return { x, y };
-}
-
-// Improved label overlap prevention
-function preventLabelOverlaps() {
-  const labelData = labelElements.data();
-  if (!labelData.length) return;
-  
-  // First pass: group labels by their vertical position into rows
-  const verticalThreshold = 30;
-  const rows = [];
-  let currentRow = [];
-  
-  // Sort labels by y-position first
-  const sortedLabels = [...labelData].sort((a, b) => a.labelY - b.labelY);
-  
-  sortedLabels.forEach(label => {
-    if (!currentRow.length) {
-      currentRow.push(label);
-    } else {
-      const lastLabel = currentRow[currentRow.length - 1];
-      if (Math.abs(label.labelY - lastLabel.labelY) < verticalThreshold) {
-        currentRow.push(label);
-      } else {
-        rows.push([...currentRow]);
-        currentRow = [label];
-      }
-    }
+  nodeElements.each(function(d) {
+    const width = getNodeWidth(d);
+    const height = getNodeHeight(d);
+    
+    minX = Math.min(minX, d.x - width/2);
+    minY = Math.min(minY, d.y - height/2);
+    maxX = Math.max(maxX, d.x + width/2);
+    maxY = Math.max(maxY, d.y + height/2);
   });
   
-  // Add the last row
-  if (currentRow.length) rows.push(currentRow);
+  // Add padding
+  const padding = 50;
+  minX -= padding;
+  minY -= padding;
+  maxX += padding;
+  maxY += padding;
   
-  // Second pass: for each row, resolve horizontal overlaps
-  rows.forEach(row => {
-    if (row.length <= 1) return; // No overlaps with single label
-    
-    // Sort by x-position
-    row.sort((a, b) => a.labelX - b.labelX);
-    
-    // Get label widths and calculate minimum required space
-    const labelWidths = row.map(label => {
-      const labelIndex = labelData.indexOf(label);
-      const labelElement = d3.select(labelElements.nodes()[labelIndex]);
-      const labelBg = labelElement.select('.label-bg').node();
-      return labelBg ? labelBg.getBBox().width : 0;
-    });
-    
-    // Calculate total width and required spacing
-    const minSpacing = 30; // Increased minimum spacing between labels
-    
-    // Check for overlaps and adjust positions
-    for (let i = 0; i < row.length - 1; i++) {
-      const currentLabel = row[i];
-      const nextLabel = row[i + 1];
-      
-      const currentWidth = labelWidths[i];
-      const nextWidth = labelWidths[i + 1];
-      
-      const currentRight = currentLabel.labelX + (currentWidth / 2);
-      const nextLeft = nextLabel.labelX - (nextWidth / 2);
-      
-      // If labels overlap or are too close
-      if (nextLeft - currentRight < minSpacing) {
-        // Calculate how much we need to move
-        const moveDistance = (minSpacing - (nextLeft - currentRight)) / 2;
-        
-        // Move current label left and next label right
-        if (currentLabel.path && nextLabel.path) {
-          // Adjust position ratios to move labels apart
-          currentLabel.positionRatio = Math.max(0.4, currentLabel.positionRatio - 0.1);
-          nextLabel.positionRatio = Math.min(0.9, nextLabel.positionRatio + 0.1);
-          
-          // Update positions based on new ratios
-          const currentPoint = currentLabel.path.getPointAtLength(currentLabel.pathLength * currentLabel.positionRatio);
-          const nextPoint = nextLabel.path.getPointAtLength(nextLabel.pathLength * nextLabel.positionRatio);
-          
-          currentLabel.labelX = currentPoint.x;
-          currentLabel.labelY = currentPoint.y;
-          nextLabel.labelX = nextPoint.x;
-          nextLabel.labelY = nextPoint.y;
-          
-          // Update the DOM
-          const currentIndex = labelData.indexOf(currentLabel);
-          const nextIndex = labelData.indexOf(nextLabel);
-          
-          d3.select(labelElements.nodes()[currentIndex])
-            .attr('transform', `translate(${currentLabel.labelX}, ${currentLabel.labelY})`);
-          
-          d3.select(labelElements.nodes()[nextIndex])
-            .attr('transform', `translate(${nextLabel.labelX}, ${nextLabel.labelY})`);
-        } else {
-          // Fallback if path information is not available
-          currentLabel.labelX -= moveDistance;
-          nextLabel.labelX += moveDistance;
-          
-          const currentIndex = labelData.indexOf(currentLabel);
-          const nextIndex = labelData.indexOf(nextLabel);
-          
-          d3.select(labelElements.nodes()[currentIndex])
-            .attr('transform', `translate(${currentLabel.labelX}, ${currentLabel.labelY})`);
-          
-          d3.select(labelElements.nodes()[nextIndex])
-            .attr('transform', `translate(${nextLabel.labelX}, ${nextLabel.labelY})`);
-        }
-      }
-    }
-  });
+  // Calculate the scale and translate to fit all nodes
+  const graphWidth = maxX - minX;
+  const graphHeight = maxY - minY;
+  const scale = Math.min(width / graphWidth, height / graphHeight, 1);
   
-  // Third pass: stagger labels vertically within rows to further reduce overlaps
-  rows.forEach(row => {
-    if (row.length <= 2) return; // No need to stagger if only 1-2 labels
-    
-    row.forEach((label, i) => {
-      // Apply a slight vertical offset based on position in row
-      // Odd indices go up, even indices go down
-      const verticalOffset = (i % 2 === 0) ? -15 : 15;
-      
-      label.labelY += verticalOffset;
-      
-      // Update the DOM
-      const labelIndex = labelData.indexOf(label);
-      d3.select(labelElements.nodes()[labelIndex])
-        .attr('transform', `translate(${label.labelX}, ${label.labelY})`);
-    });
-  });
+  const translateX = width/2 - (minX + maxX)/2 * scale;
+  const translateY = height/2 - (minY + maxY)/2 * scale;
+  
+  // Apply the zoom transform
+  d3.select('#graph').transition().duration(750).call(
+    zoom.transform,
+    d3.zoomIdentity.translate(translateX, translateY).scale(scale)
+  );
 }
 </script>
+</body>
+</html>

--- a/relations/index.html
+++ b/relations/index.html
@@ -1128,7 +1128,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Reset zoom and pan
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(width/2, height/2).scale(0.7) // Start with a zoomed-out view
+    d3.zoomIdentity.translate(width/2, height/2).scale(0.6) // Start with a more zoomed-out view
   );
   
   // Create the graph content group
@@ -1474,17 +1474,17 @@ function renderD3Graph(rootSubject, nodes, edges) {
           
           if (!sourceNode || !targetNode) {
             console.warn("Missing node in link distance calculation");
-            return forceParams.linkDistance;
+            return forceParams.linkDistance * 2.0; // Further increased distance
           }
           
           const sourceSize = Math.sqrt(getNodeWidth(sourceNode) * getNodeHeight(sourceNode));
           const targetSize = Math.sqrt(getNodeWidth(targetNode) * getNodeHeight(targetNode));
           
           // Base distance on node sizes plus padding - increased for better spacing
-          return (sourceSize + targetSize) / 2 + forceParams.linkDistance * 1.5; // Increased distance multiplier
+          return (sourceSize + targetSize) / 2 + forceParams.linkDistance * 2.0; // Further increased distance multiplier
         } catch (error) {
           console.error("Error in link distance calculation:", error, d);
-          return forceParams.linkDistance * 1.5; // Increased default distance
+          return forceParams.linkDistance * 2.0; // Further increased default distance
         }
       })
     )
@@ -1492,28 +1492,28 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .strength(d => {
         // Stronger repulsion for structured layout
         const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
-        return forceParams.charge * (nodeSize / 200) * 2.0; // Increased repulsion
+        return forceParams.charge * (nodeSize / 200) * 2.5; // Further increased repulsion
       })
-      .distanceMin(250) // Increased minimum distance
-      .distanceMax(2500)) // Increased maximum distance
+      .distanceMin(300) // Further increased minimum distance
+      .distanceMax(3000)) // Further increased maximum distance
     .force('x', d3.forceX(d => {
       // Keep root node centered, let others spread horizontally
       if (d.id === rootSubject) return width / 2;
       return d.x; // Use pre-positioned x value
-    }).strength(d => d.id === rootSubject ? 1 : 0.15)) // Reduced strength to allow more movement
+    }).strength(d => d.id === rootSubject ? 1 : 0.1)) // Further reduced strength to allow more movement
     .force('y', d3.forceY(d => {
       // Keep root node at top, others in row below
       if (d.id === rootSubject) return height * 0.2;
       return height * 0.7;
-    }).strength(0.2)) // Reduced strength to allow more movement
+    }).strength(0.15)) // Further reduced strength to allow more movement
     .force('collision', d3.forceCollide().radius(d => {
       // Make collision radius based on node size plus padding
       const nodeWidth = getNodeWidth(d);
       const nodeHeight = getNodeHeight(d);
-      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 100; // Increased padding significantly
+      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 120; // Further increased padding significantly
     }).strength(1))
-    .alpha(0.8) // Higher alpha for more movement
-    .alphaDecay(0.006) // Slower decay for more time to find optimal positions
+    .alpha(0.9) // Higher alpha for more movement
+    .alphaDecay(0.005) // Slower decay for more time to find optimal positions
     .velocityDecay(0.4)
     .on('tick', ticked);
 }
@@ -1759,7 +1759,8 @@ function preventLabelOverlaps() {
         width: getNodeWidth(d),
         height: getNodeHeight(d),
         id: d.id,
-        type: 'node'
+        type: 'node',
+        center: { x: d.x, y: d.y }
       });
     });
     
@@ -1780,6 +1781,12 @@ function preventLabelOverlaps() {
       const labelX = d.labelX || 0;
       const labelY = d.labelY || 0;
       
+      // Get source and target nodes for this edge
+      const sourceNode = nodeMap.get(d.from);
+      const targetNode = nodeMap.get(d.to);
+      
+      if (!sourceNode || !targetNode) return;
+      
       labelRects.push({
         x: labelX - labelBBox.width / 2,
         y: labelY - labelBBox.height / 2,
@@ -1789,7 +1796,10 @@ function preventLabelOverlaps() {
         group: labelGroup,
         originalX: labelX,
         originalY: labelY,
-        type: 'label'
+        type: 'label',
+        sourceNode: sourceNode,
+        targetNode: targetNode,
+        center: { x: labelX, y: labelY }
       });
     });
     
@@ -1828,6 +1838,26 @@ function preventLabelOverlaps() {
             }
           }
         }
+        
+        // If we still have overlaps after several attempts, try a more drastic approach
+        if (hasOverlap && attempts >= 5) {
+          // Try positioning at different angles around the midpoint between source and target
+          const sourceCenter = labelRect.sourceNode;
+          const targetCenter = labelRect.targetNode;
+          
+          if (sourceCenter && targetCenter) {
+            const midX = (sourceCenter.x + targetCenter.x) / 2;
+            const midY = (sourceCenter.y + targetCenter.y) / 2;
+            
+            // Calculate distance to place label
+            const distance = Math.max(labelRect.width, labelRect.height) * 1.5;
+            
+            // Try different angles
+            const angle = (Math.PI * 2 * attempts) / maxAttempts;
+            labelRect.x = midX + Math.cos(angle) * distance - labelRect.width / 2;
+            labelRect.y = midY + Math.sin(angle) * distance - labelRect.height / 2;
+          }
+        }
       }
       
       // Update the label position
@@ -1848,7 +1878,7 @@ function preventLabelOverlaps() {
 // Helper function to check if two rectangles overlap
 function rectsOverlap(rect1, rect2) {
   // Add a buffer zone to ensure labels don't touch
-  const buffer = 15;
+  const buffer = 25; // Increased buffer
   
   return !(
     rect1.x + rect1.width + buffer < rect2.x ||
@@ -1884,10 +1914,10 @@ function repositionLabelAwayFromRect(labelRect, overlapRect) {
   const overlapY = minDistY - Math.abs(labelCenterY - rectCenterY);
   
   // Add a larger buffer to ensure no overlap
-  const buffer = 20;
+  const buffer = 30; // Increased buffer
   
   // Move in the direction with the least overlap, but with a minimum movement
-  const moveDistance = Math.max(Math.min(overlapX, overlapY) + buffer, 30);
+  const moveDistance = Math.max(Math.min(overlapX, overlapY) + buffer, 40); // Increased minimum distance
   
   if (overlapX < overlapY) {
     // Move horizontally

--- a/relations/index.html
+++ b/relations/index.html
@@ -40,7 +40,8 @@ title: People Relations (BETA)
     overflow: hidden;  /* if you like; up to you */
     display: flex;     /* Add flexbox to center content */
     justify-content: center; /* Center horizontally */
-    align-items: center;     /* Center vertically */
+    align-items: flex-start; /* Align to the top instead of center */
+    padding-top: 20px; /* Add some padding at the top */
   }
   #legend {
     display: flex;
@@ -1168,7 +1169,7 @@ function resetZoom() {
   // In hierarchical layout, we want to center more towards the top where the root node is
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(0, height * 0.2).scale(0.5) // Shift up slightly to focus on root
+    d3.zoomIdentity.translate(0, height * -0.1).scale(0.5) // Move even higher by using negative value
   );
 }
 
@@ -1212,14 +1213,14 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Reset zoom and pan with centered graph
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(0, 0).scale(0.5) // More zoomed out to see the entire graph
+    d3.zoomIdentity.translate(0, -height * 0.25).scale(0.5) // Increase negative offset to move higher
   );
   
   // Create the graph content group with initial transform
   const g = d3.select('#graph-content');
   
   // Explicitly set an initial transform on the graph content to center it
-  g.attr('transform', `translate(${width/2}, ${height/2})`);
+  g.attr('transform', `translate(${width/2}, ${height/4})`); // Position at 1/4 height instead of 1/3
   
   // Store the root subject for reference in other functions
   window.rootSubject = rootSubject;
@@ -1234,13 +1235,12 @@ function renderD3Graph(rootSubject, nodes, edges) {
     nodeMap.set(node.id, node);
   });
   
-  // Pre-position nodes in a structured layout - critical for avoiding initial overlaps
   // Position root node at the top center
   if (rootNode) {
     rootNode.x = 0; // Center horizontally
-    rootNode.y = -height * 0.35; // Position at top
+    rootNode.y = -height * 0.7; // Increased negative value to position even higher
     rootNode.fx = 0; // Fix position horizontally
-    rootNode.fy = -height * 0.35; // Fix position vertically
+    rootNode.fy = -height * 0.7; // Increased negative value to position even higher
   }
   
   // Arrange non-root nodes in a semi-circle below the root node
@@ -1249,7 +1249,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     // Use a semi-circle (180 degrees) below the root
     const angle = (Math.PI * i) / (nonRootNodes.length - 1);
     node.x = radius * Math.cos(angle); // Position in semi-circle
-    node.y = -height * 0.35 + radius * Math.sin(angle) + radius; // Position below root node
+    node.y = -height * 0.7 + radius * Math.sin(angle) + radius; // Position below root node
   });
   
   // Preprocess edges to ensure all source and target nodes exist
@@ -1747,7 +1747,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
       return d.x;
     }).strength(0.25))
     .force('y', d3.forceY(d => {
-      if (d.id === rootSubject) return -height * 0.4;
+      if (d.id === rootSubject) return -height * 0.7; // Increased negative value for higher positioning
       if (firstLevelNodeIds.has(d.id)) {
         return d.y; // Keep first level at their y positions
       }
@@ -1810,7 +1810,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     }).strength(d => d.id === rootSubject ? 1 : 0.3)) // Increased from 0.2 for faster positioning
     .force('y', d3.forceY(d => {
       // Keep root at top
-      if (d.id === rootSubject) return -height * 0.3; // Reduced from 0.4
+      if (d.id === rootSubject) return -height * 0.7; // Increased negative value for higher positioning
       
       // First level nodes position
       if (firstLevelNodeIds.has(d.id)) {
@@ -1974,11 +1974,11 @@ function centerGraph() {
     // Calculate the center of the graph content with emphasis on the root node
     // For knowledge graphs, we want the root higher in the viewport
     const graphCenterX = bbox.x + bbox.width / 2;
-    const graphCenterY = bbox.y + bbox.height * 0.35; // 35% point to shift focus upward
+    const graphCenterY = bbox.y + bbox.height * 0.15; // 15% point to shift focus even further upward
     
     // Calculate the translation needed to center the graph
     const translateX = viewportWidth / 2 - graphCenterX;
-    const translateY = viewportHeight / 2 - graphCenterY;
+    const translateY = viewportHeight / 5 - graphCenterY; // Position at 1/5 of the height instead of 1/3
     console.log("Translation:", translateX, translateY);
     
     // Determine appropriate initial scale based on the graph size
@@ -2025,9 +2025,9 @@ function ticked() {
     simulation.nodes().forEach(d => {
       if (d.id === rootSubject) {
         d.x = 0;
-        d.y = -height * 0.4;
+        d.y = -height * 0.5; // Increased to position higher (was 0.4)
         d.fx = 0;
-        d.fy = -height * 0.4;
+        d.fy = -height * 0.5; // Increased to position higher (was 0.4)
       }
     });
     

--- a/relations/index.html
+++ b/relations/index.html
@@ -698,6 +698,24 @@ async function renderGraphForSubject(subjectName) {
       throw new Error(`Subject "${subjectName}" not found`);
     }
     
+    // Populate the root summary div with bullet points
+    const rootSummaryHtml = [];
+    if (subject.bullet_point1) {
+      rootSummaryHtml.push(`<p class="mb-1">${escapeHtml(subject.bullet_point1)}</p>`);
+    }
+    if (subject.bullet_point2) {
+      rootSummaryHtml.push(`<p>${escapeHtml(subject.bullet_point2)}</p>`);
+    }
+    // If no bullet points, add a default message
+    if (rootSummaryHtml.length === 0) {
+      rootSummaryHtml.push(`<p class="text-gray-500 italic">No detailed information available for ${escapeHtml(subjectName)}.</p>`);
+    }
+    // Add a title for the summary
+    $('#rootSummary').html(`
+      <h3 class="font-bold mb-2 text-navy">${escapeHtml(subjectName)}</h3>
+      ${rootSummaryHtml.join('')}
+    `);
+    
     // Load relations data for this subject
     await loadRelationsData(subjectName);
     

--- a/relations/index.html
+++ b/relations/index.html
@@ -92,9 +92,25 @@ title: People Relations (BETA)
     margin-right: 4px;
     margin-bottom: 4px;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+  .legend-item:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   }
   .legend-item.disabled {
     opacity: 0.5;
+    position: relative;
+  }
+  .legend-item.disabled::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(255, 255, 255, 0.3);
+    border-radius: 4px;
   }
   
   /* Hover effects - using !important to override any inline styles */
@@ -839,6 +855,20 @@ async function renderGraphForSubject(subjectName) {
       }
     }
     
+    // Collect unique categories for the legend
+    const uniqueCategories = new Set();
+    for (const edge of edges) {
+      if (edge.category) {
+        uniqueCategories.add(edge.category);
+      }
+    }
+    
+    // Initialize active categories with all categories
+    globalActiveCategories = new Set(uniqueCategories);
+    
+    // Render the legend
+    renderLegend(Array.from(uniqueCategories));
+    
     // Render the graph
     renderD3Graph(subjectName, nodes, edges);
     
@@ -1016,9 +1046,6 @@ function toggleCategory(cat) {
     globalActiveCategories.add(cat);
   }
   
-  // Filter edges based on active categories
-  const activeEdges = globalAllEdges.filter(e => globalActiveCategories.has(e.category));
-  
   // Update edge visibility
   linkElements.attr('visibility', d => 
     globalActiveCategories.has(d.category) ? 'visible' : 'hidden'
@@ -1028,6 +1055,19 @@ function toggleCategory(cat) {
   labelElements.attr('visibility', d => 
     globalActiveCategories.has(d.category) ? 'visible' : 'hidden'
   );
+  
+  // Update edge marker visibility (arrows)
+  linkElements.attr('marker-end', d => 
+    globalActiveCategories.has(d.category) 
+      ? `url(#arrow-${d.category || 'UNKNOWN'})` 
+      : 'none'
+  );
+  
+  // Update legend items visual state
+  $('.legend-item').each(function() {
+    const category = $(this).data('cat');
+    $(this).toggleClass('disabled', !globalActiveCategories.has(category));
+  });
 }
 
 
@@ -1155,7 +1195,22 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Add arrow markers for links
   const defs = g.append('defs');
   
-  // Regular arrow marker
+  // Create marker definitions for each category
+  Object.entries(categoryColors).forEach(([category, color]) => {
+    defs.append('marker')
+      .attr('id', `arrow-${category}`)
+      .attr('viewBox', '0 -5 10 10')
+      .attr('refX', 20)
+      .attr('refY', 0)
+      .attr('markerWidth', 8)
+      .attr('markerHeight', 8)
+      .attr('orient', 'auto')
+      .append('path')
+      .attr('fill', color)
+      .attr('d', 'M0,-5L10,0L0,5');
+  });
+  
+  // Regular arrow marker (fallback)
   defs.append('marker')
     .attr('id', 'arrow')
     .attr('viewBox', '0 -5 10 10')
@@ -1249,11 +1304,15 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .data(validEdges)
     .join('path')
     .attr('class', 'link')
-    .attr('stroke', d => d.color)
+    .attr('stroke', d => {
+      // Get the color from the category using the global categoryColors
+      return categoryColors[d.category] || categoryColors["UNKNOWN"];
+    })
     .attr('stroke-width', 2)
-    .attr('marker-end', 'url(#arrow)')
+    .attr('marker-end', d => `url(#arrow-${d.category || 'UNKNOWN'})`)
     .attr('data-source', d => d.from)
     .attr('data-target', d => d.to)
+    .attr('data-category', d => d.category)
     .style('cursor', 'pointer')
     .on('mouseover', function(event, d) {
       console.log('Link path hover:', d);
@@ -1467,7 +1526,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     linkElements
       .style('stroke', null)
       .style('stroke-width', null)
-      .attr('stroke', d => d.color)
+      .attr('stroke', d => categoryColors[d.category] || categoryColors["UNKNOWN"])
       .attr('stroke-width', 2);
     
     // Reset label styles

--- a/relations/index.html
+++ b/relations/index.html
@@ -42,17 +42,6 @@ title: People Relations (BETA)
     justify-content: center; /* Center horizontally */
     align-items: center;     /* Center vertically */
   }
-  #loading {
-    position: absolute;
-    inset: 0;
-    background-color: white;
-    z-index: 30;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    opacity: 1;
-    transition: opacity 0.3s ease-out;
-  }
   #legend {
     display: flex;
     align-items: flex-start;
@@ -269,7 +258,7 @@ It shows the generated graph and a legend, plus a button to go back to the searc
     <g id="graph-content"></g>
   </svg>
   <!-- Add loading overlay with the same styling as in expose/index.html -->
-  <div id="loading" class="absolute inset-0 flex flex-col items-center justify-start pt-16 bg-white z-30">
+  <div id="loading" class="absolute inset-0 flex flex-col items-center justify-start bg-white pt-4 h-full z-30">
     <div class="text-center">
       <svg class="animate-spin h-8 w-8 text-navy mx-auto mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -1193,7 +1182,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // That will be hidden in the centerGraph function when "Graph centered based on actual bounds" is logged
   
   // Update loading text to show that the graph is being processed
-  $('#loading-text').text('Rendering graph visualization...');
+  $('#loading-text').text('Analyzing connections...');
   
   // Remove the premature timeout - we'll let the centerGraph function handle hiding the overlay
   // instead of this fixed 10-second timer
@@ -1858,14 +1847,42 @@ function displayNodesProgressively() {
     // Add root node first
     if (rootNode) {
       const rootDiv = document.createElement('div');
-      rootDiv.className = 'font-bold opacity-0 transition-opacity duration-300 py-1';
-      rootDiv.textContent = rootNode.id;
+      rootDiv.className = 'opacity-0 transition-opacity duration-300 py-1';
+      
+      // Add the root node ID as the main text
+      const nodeIdSpan = document.createElement('div');
+      nodeIdSpan.className = 'font-bold';
+      nodeIdSpan.textContent = rootNode.id;
+      rootDiv.appendChild(nodeIdSpan);
+      
+      // Add text indicating this is the root node
+      const relationSpan = document.createElement('div');
+      relationSpan.className = 'text-sm opacity-80 ml-2';
+      relationSpan.textContent = '(root node)';
+      rootDiv.appendChild(relationSpan);
+      
       loadingNodesDiv.appendChild(rootDiv);
       
       // Trigger fade in for root node
       setTimeout(() => {
         rootDiv.style.opacity = '1';
       }, 100);
+    }
+    
+    // Function to find relationship labels between root and a node
+    function getRelationshipLabels(nodeId) {
+      const relationships = [];
+      
+      // Check for edges from root to this node
+      window.edges.forEach(edge => {
+        if (edge.from === rootSubject && edge.to === nodeId) {
+          relationships.push(edge.label || "unlabeled relation");
+        } else if (edge.to === rootSubject && edge.from === nodeId) {
+          relationships.push(edge.label || "unlabeled relation");
+        }
+      });
+      
+      return relationships;
     }
     
     // Add first-level nodes progressively
@@ -1876,8 +1893,23 @@ function displayNodesProgressively() {
         
         // Create element for this node
         const div = document.createElement('div');
-        div.className = 'opacity-0 transition-opacity duration-300 py-1';
-        div.textContent = node.id;
+        div.className = 'opacity-0 transition-opacity duration-300 py-2';
+        
+        // Add the node ID as the main text
+        const nodeIdSpan = document.createElement('div');
+        nodeIdSpan.textContent = node.id;
+        div.appendChild(nodeIdSpan);
+        
+        // Add relationship labels
+        const relationships = getRelationshipLabels(node.id);
+        if (relationships.length > 0) {
+          relationships.forEach(label => {
+            const relationSpan = document.createElement('div');
+            relationSpan.className = 'text-sm opacity-80 ml-2';
+            relationSpan.textContent = label;
+            div.appendChild(relationSpan);
+          });
+        }
         
         // Add to container
         loadingNodesDiv.appendChild(div);

--- a/relations/index.html
+++ b/relations/index.html
@@ -1389,12 +1389,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .data(nodes)
     .join('g')
     .attr('class', d => d.id === rootSubject ? 'node root' : 'node')
-    .attr('data-id', d => d.id)
-    .call(d3.drag()
-      .on('start', dragStarted)
-      .on('drag', dragged)
-      .on('end', dragEnded)
-    );
+    .attr('data-id', d => d.id);
    
   // Start displaying first-level nodes progressively now that nodeElements is defined
   displayNodesProgressively();
@@ -1408,7 +1403,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .attr('fill', 'white')
     .attr('stroke', d => d.id === rootSubject ? '#2563EB' : '#94A3B8')
     .attr('stroke-width', d => d.id === rootSubject ? 3 : 1)
-    .style('cursor', 'grab')
+    .style('cursor', 'default') // Changed from 'grab' to 'default'
     .on('mouseover', function(event, d) {
       console.log('Node rect hover:', d);
       
@@ -2879,29 +2874,6 @@ function wrapText(text, maxChars) {
   return lines;
 }
 
-// Drag functions for nodes
-function dragStarted(event, d) {
-  if (!event.active) simulation.alphaTarget(0.3).restart();
-  d.fx = d.x;
-  d.fy = d.y;
-  d3.select(this).select('rect').style('cursor', 'grabbing');
-}
-
-function dragged(event, d) {
-  d.fx = event.x;
-  d.fy = event.y;
-}
-
-function dragEnded(event, d) {
-  if (!event.active) simulation.alphaTarget(0);
-  // Keep root node fixed, release others
-  if (d.id !== rootSubject) {
-    d.fx = null;
-    d.fy = null;
-  }
-  d3.select(this).select('rect').style('cursor', 'grab');
-}
-
 // Function to zoom to fit all nodes
 function zoomToFitAll() {
   // Get the bounds of all nodes
@@ -2938,6 +2910,8 @@ function zoomToFitAll() {
     d3.zoomIdentity.translate(translateX, translateY).scale(scale)
   );
 }
+
+// Remove drag functions since we disabled node dragging
 
 function buildGraph(subject, filterKeywords = []) {
   // Update page title with subject name

--- a/relations/index.html
+++ b/relations/index.html
@@ -704,7 +704,13 @@ function renderSearchResult(subject, desc) {
   `);
 
   $div.css('cursor','pointer').on('click', function() {
-    window.location.href = '?subject=' + encodeURIComponent(subject);
+    // Get current search value
+    const searchValue = $('#searchBox').val().trim();
+    let url = '?subject=' + encodeURIComponent(subject);
+    if (searchValue) {
+      url += '&search=' + encodeURIComponent(searchValue);
+    }
+    window.location.href = url;
   });
 
   return $div;
@@ -715,8 +721,16 @@ function renderSearchResult(subject, desc) {
 * BACK TO SEARCH
 ***************************************/
 $('#backToSearch').on('click', function() {
+  const urlParams = new URLSearchParams(window.location.search);
+  const searchValue = urlParams.get('search');
+  
   const newUrl = new URL(window.location);
   newUrl.searchParams.delete('subject');
+  
+  if (searchValue) {
+    newUrl.searchParams.set('search', searchValue);
+  }
+  
   window.history.pushState({}, '', newUrl);
   window.location.reload();
 });

--- a/relations/index.html
+++ b/relations/index.html
@@ -35,12 +35,15 @@ title: People Relations (BETA)
   }
   #graph-container {
     width: 100%;
-    height: 80vh;      /* or calc(100vh - someOffset) */
+    height: 70vh;
     position: relative;
-    overflow: hidden;  /* if you like; up to you */
-    display: flex;     /* Add flexbox to center content */
-    justify-content: center; /* Center horizontally */
-    align-items: flex-start; /* Align to the top instead of center */
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.375rem;
   }
   #legend {
     display: flex;
@@ -240,7 +243,24 @@ It shows the generated graph and a legend, plus a button to go back to the searc
 <div id="rootSummary" class="mb-4 p-2 md:px-4 md:pt-3 border rounded text-sm bg-white"></div>
 
 <!-- Where the graph renders -->
-<div id="graph-container" class="border rounded flex items-center justify-center bg-white">
+<div id="graph-container">
+  <div class="absolute bottom-4 right-4 z-10 flex flex-col gap-1">
+    <button id="zoomIn" class="p-2 rounded min-w-0 mr-0 bg-black/60 hover:bg-black text-white">
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
+      </svg>
+    </button>
+    <button id="zoomOut" class="p-2 rounded min-w-0 mr-0 bg-black/60 hover:bg-black text-white">
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4"/>
+      </svg>
+    </button>
+    <button id="zoomFit" class="p-2 rounded min-w-0 mr-0 bg-black/60 hover:bg-black text-white">
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-5V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5"/>
+      </svg>
+    </button>
+  </div>
   <svg id="graph" width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
     <defs>
       <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
@@ -251,6 +271,7 @@ It shows the generated graph and a legend, plus a button to go back to the searc
     </defs>
     <g id="graph-content"></g>
   </svg>
+
   <!-- Add loading overlay with the same styling as in expose/index.html -->
   <div id="loading" class="absolute inset-0 flex flex-col items-center justify-start bg-white pt-4 h-full z-30">
     <div class="text-center">
@@ -268,6 +289,8 @@ It shows the generated graph and a legend, plus a button to go back to the searc
     <img src="../assets/images/loading.svg" class="loading-spinner" style="width:32px;height:32px" alt="Loading...">
   </div>
 </div>
+
+
 
 <!-- Download button -->
 <div class="mt-2 text-right">
@@ -2908,6 +2931,17 @@ function zoomToFitAll() {
     d3.zoomIdentity.translate(translateX, translateY).scale(scale)
   );
 }
+
+// Handle zoom controls
+document.getElementById('zoomIn').onclick = () => {
+  d3.select('#graph').transition().duration(300).call(zoom.scaleBy, 1.3);
+};
+
+document.getElementById('zoomOut').onclick = () => {
+  d3.select('#graph').transition().duration(300).call(zoom.scaleBy, 0.7);
+};
+
+document.getElementById('zoomFit').onclick = zoomToFitAll;
 
 // Remove drag functions since we disabled node dragging
 

--- a/relations/index.html
+++ b/relations/index.html
@@ -313,14 +313,14 @@ let globalActiveCategories = new Set(); // which categories are currently on dis
 
 // Force simulation parameters
 const forceParams = {
-  linkDistance: 600,     // Increased from 400
-  charge: -5000,         // Increased from -3000
-  collisionRadius: 300,  // Increased from 200
+  linkDistance: 1200,     // Doubled from 600
+  charge: -10000,         // Doubled from -5000
+  collisionRadius: 500,   // Increased from 300
   bounds: {
-    left: 150,
-    right: 150,
-    top: 150,
-    bottom: 150
+    left: 300,
+    right: 300,
+    top: 300,
+    bottom: 300
   }
 };
 
@@ -724,7 +724,7 @@ async function renderGraphForSubject(subjectName) {
     }
     // Add a title for the summary
     $('#rootSummary').html(`
-      <h3 class="font-bold mb-2 text-navy">${escapeHtml(subjectName)}</h3>
+      <h3 class="font-bold mt-0 mb-2 text-navy">${escapeHtml(subjectName)}</h3>
       ${rootSummaryHtml.join('')}
     `);
     
@@ -1128,7 +1128,7 @@ function initializeD3Graph() {
   
   // Set the SVG viewBox to cover the entire container
   d3.select('#graph')
-    .attr('viewBox', `${-width/2} ${-height/2} ${width} ${height}`)
+    .attr('viewBox', `${-width/1.5} ${-height/1.5} ${width*1.5} ${height*1.5}`)
     .attr('preserveAspectRatio', 'xMidYMid meet');
   
   // Initialize zoom behavior
@@ -1154,7 +1154,7 @@ function resetZoom() {
   // Center the graph with an appropriate scale
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(0, 0).scale(0.8)
+    d3.zoomIdentity.translate(0, 0).scale(0.5) // More zoomed out to see the entire graph
   );
 }
 
@@ -1187,7 +1187,7 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Reset zoom and pan with centered graph
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(0, 0).scale(0.8) // Center at origin
+    d3.zoomIdentity.translate(0, 0).scale(0.5) // More zoomed out to see the entire graph
   );
   
   // Create the graph content group with initial transform
@@ -1546,44 +1546,23 @@ function renderD3Graph(rootSubject, nodes, edges) {
     .force('link', d3.forceLink()
       .links(validEdges)
       .id(d => d.id)
-      .distance(d => {
-        try {
-          // Get source and target nodes
-          const sourceNode = d.source;
-          const targetNode = d.target;
-          
-          if (!sourceNode || !targetNode) {
-            console.warn("Missing node in link distance calculation");
-            return forceParams.linkDistance * 1.5; // Moderately increased distance
-          }
-          
-          const sourceSize = Math.sqrt(getNodeWidth(sourceNode) * getNodeHeight(sourceNode));
-          const targetSize = Math.sqrt(getNodeWidth(targetNode) * getNodeHeight(targetNode));
-          
-          // Base distance on node sizes plus padding - increased for better spacing
-          return (sourceSize + targetSize) / 2 + forceParams.linkDistance;
-        } catch (error) {
-          console.error("Error in link distance calculation:", error, d);
-          return forceParams.linkDistance * 1.5; // Moderately increased default distance
-        }
-      })
-    )
+      .distance(forceParams.linkDistance * 2)) // Double the link distance
     .force('charge', d3.forceManyBody()
       .strength(d => {
         // Stronger repulsion for structured layout
         const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
-        return forceParams.charge * (nodeSize / 200) * 1.5; // Moderately increased repulsion
+        return forceParams.charge * (nodeSize / 200) * 2.5; // Significantly increased repulsion
       })
-      .distanceMin(300) // Further increased minimum distance
-      .distanceMax(3000)) // Further increased maximum distance
+      .distanceMin(400) // Increased minimum distance
+      .distanceMax(5000)) // Increased maximum distance
     .force('x', d3.forceX(0).strength(0.2)) // Center nodes horizontally at origin
     .force('y', d3.forceY(0).strength(0.2)) // Center nodes vertically at origin
     .force('collision', d3.forceCollide().radius(d => {
       // Make collision radius based on node size plus padding
       const nodeWidth = getNodeWidth(d);
       const nodeHeight = getNodeHeight(d);
-      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 100; // Increased padding significantly
-    }).strength(0.8))
+      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 200; // Significantly increased padding
+    }).strength(1))
     .alpha(0.8) // Higher alpha for more movement
     .alphaDecay(0.01) // Slower decay for more time to find optimal positions
     .velocityDecay(0.4)
@@ -1611,7 +1590,7 @@ function centerGraph() {
     // Update the zoom transform to center the graph
     d3.select('#graph').call(
       zoom.transform,
-      d3.zoomIdentity.translate(translateX, translateY).scale(0.8)
+      d3.zoomIdentity.translate(translateX, translateY).scale(0.5)
     );
     
     console.log('Graph centered based on actual bounds:', { 
@@ -1699,13 +1678,13 @@ function ticked() {
         // Create path with more segments to avoid running behind nodes
         let path = '';
         
-        // Add a small offset to ensure arrows don't touch nodes
-        const arrowOffset = 10;
+        // Remove the offset to ensure lines connect directly to nodes without gaps
+        const arrowOffset = 0;
         
-        // Adjust target point to account for arrow
+        // Adjust target point to account for arrow - no offset to avoid gaps
         const targetPointWithOffset = {
-          x: targetPoint.x + (sourcePoint.x > targetPoint.x ? arrowOffset : -arrowOffset),
-          y: targetPoint.y + (sourcePoint.y > targetPoint.y ? arrowOffset : -arrowOffset)
+          x: targetPoint.x,
+          y: targetPoint.y
         };
         
         if (isHorizontal) {
@@ -1778,15 +1757,15 @@ function ticked() {
                 const midX = (source.x + target.x) / 2;
                 midY = source.y + (target.y - source.y) / 2;
                 
-                // Offset the label to avoid overlapping with the path
-                midY += (source.y > target.y) ? -20 : 20;
+                // Increase offset to avoid overlap
+                midY += (source.y > target.y) ? -40 : 40;
               } else {
                 // For vertical paths, position label to the left or right of the middle segment
                 midX = source.x + (target.x - source.x) / 2;
                 const midY = (source.y + target.y) / 2;
                 
-                // Offset the label to avoid overlapping with the path
-                midX += (source.x > target.x) ? -20 : 20;
+                // Increase offset to avoid overlap
+                midX += (source.x > target.x) ? -40 : 40;
               }
             }
           } else {

--- a/relations/index.html
+++ b/relations/index.html
@@ -42,6 +42,17 @@ title: People Relations (BETA)
     justify-content: center; /* Center horizontally */
     align-items: center;     /* Center vertically */
   }
+  #loading {
+    position: absolute;
+    inset: 0;
+    background-color: white;
+    z-index: 30;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 1;
+    transition: opacity 0.3s ease-out;
+  }
   #legend {
     display: flex;
     align-items: flex-start;
@@ -251,12 +262,22 @@ It shows the generated graph and a legend, plus a button to go back to the searc
     <defs>
       <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
         markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-        <path d="M 0 0 L 10 5 L 0 10 z" fill="#94A3B8" />
+        <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-path"></path>
       </marker>
       <!-- Category-specific markers will be added dynamically by D3 -->
     </defs>
     <g id="graph-content"></g>
   </svg>
+  <!-- Add loading overlay with the same styling as in expose/index.html -->
+  <div id="loading" class="absolute inset-0 flex flex-col items-center justify-center pt-5 bg-white z-30">
+    <div class="text-center">
+      <svg class="animate-spin h-8 w-8 text-navy mx-auto mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+      </svg>
+      <div id="loading-text" class="text-lg font-semibold text-navy mb-4">Loading graph...</div>
+    </div>
+  </div>
   <div id="loading-indicator" class="absolute">
     <img src="../assets/images/loading.svg" class="loading-spinner" style="width:32px;height:32px" alt="Loading...">
   </div>
@@ -1164,6 +1185,11 @@ function renderD3Graph(rootSubject, nodes, edges) {
   
   // Hide loading indicator when rendering starts
   $('#loading-indicator').hide();
+  // Note: We keep the main 'loading' overlay visible until the graph is fully centered
+  // That will be hidden in the centerGraph function when "Graph centered based on actual bounds" is logged
+  
+  // Update loading text to show that the graph is being processed
+  $('#loading-text').text('Rendering graph visualization...');
   
   // Initialize container dimensions
   const container = document.getElementById('graph-container');
@@ -1598,6 +1624,16 @@ function centerGraph() {
       graphCenter: { x: graphCenterX, y: graphCenterY },
       translation: { x: translateX, y: translateY }
     });
+    
+    // Hide the loading overlay when the graph is fully loaded and centered
+    const loadingEl = document.getElementById('loading');
+    if (loadingEl) {
+      loadingEl.style.opacity = '0';
+      loadingEl.style.transition = 'opacity 0.3s ease-out';
+      setTimeout(() => {
+        loadingEl.style.display = 'none';
+      }, 300);
+    }
   } catch (error) {
     console.error('Error centering graph:', error);
   }
@@ -2298,6 +2334,29 @@ function zoomToFitAll() {
     zoom.transform,
     d3.zoomIdentity.translate(translateX, translateY).scale(scale)
   );
+}
+
+function buildGraph(subject, filterKeywords = []) {
+  // Update page title with subject name
+  try {
+    const subjectName = nameFromEntityId(subject);
+    document.title = `${subjectName} - People Relations`;
+    $('#graphTitle').text(`${subjectName} - Relationship Graph`);
+  } catch (e) {
+    document.title = "People Relations";
+    $('#graphTitle').text("Relationship Graph");
+  }
+  
+  // Update loading overlay text
+  $('#loading-text').text('Preparing graph data...');
+  $('#loading').show(); // Ensure loading overlay is visible
+  
+  // Show loading indicator
+  $('#loading-indicator').show();
+  
+  // Start fetch process
+  const relationsZip = `../data/${subject}.zip`;
+  // ... existing code ...
 }
 </script>
 </body>

--- a/relations/index.html
+++ b/relations/index.html
@@ -1939,9 +1939,12 @@ function getNodeWidth(node) {
     const bullet1 = bulletInfo.bullet_point1 || '';
     const bullet2 = bulletInfo.bullet_point2 || '';
     
+    // Use consistent padding for all nodes
+    const padding = 12;
+    
     // If there are no bullet points, use a smaller width
     if (bullet1.length === 0 && bullet2.length === 0) {
-      node._width = Math.max(textLength * 8 + 40, 120);
+      node._width = Math.max(textLength * 8 + padding * 2, 120);
       return node._width;
     }
     
@@ -1957,8 +1960,8 @@ function getNodeWidth(node) {
     // This ensures text fills the box better
     const targetCharsPerLine = 45;
     const contentBasedWidth = Math.min(
-      Math.max(longestBullet.length, textLength * 1.5) * charWidth + 40,
-      targetCharsPerLine * charWidth + 40
+      Math.max(longestBullet.length, textLength * 1.5) * charWidth + padding * 2,
+      targetCharsPerLine * charWidth + padding * 2
     );
     
     node._width = Math.max(contentBasedWidth, 220);

--- a/relations/index.html
+++ b/relations/index.html
@@ -1287,6 +1287,10 @@ function zoomToFitAll() {
     );
 }
 
+// Call the overlap prevention after the simulation has stabilized
+simulation.on('end', preventLabelOverlaps);
+
+// Update the ticked function to occasionally prevent overlaps
 function ticked() {
   // Update node positions
   nodeElements.attr('transform', d => {
@@ -1329,17 +1333,30 @@ function ticked() {
     
     if (!sourcePoint || !targetPoint) return '';
     
-    // Add a slight curve to the path to make overlapping paths more visible
-    const dx = targetPoint.x - sourcePoint.x;
-    const dy = targetPoint.y - sourcePoint.y;
-    const dr = Math.sqrt(dx * dx + dy * dy) * 1.2;
+    // Create orthogonal (right-angled) paths
+    // Determine if the path should go horizontally first or vertically first
+    const dx = Math.abs(targetPoint.x - sourcePoint.x);
+    const dy = Math.abs(targetPoint.y - sourcePoint.y);
     
-    // Use curved paths for better visibility when there are multiple edges
-    return `M${sourcePoint.x},${sourcePoint.y} A${dr},${dr} 0 0,1 ${targetPoint.x},${targetPoint.y}`;
+    // If nodes are more separated horizontally than vertically, go horizontal first
+    if (dx > dy) {
+      const midX = sourcePoint.x + (targetPoint.x - sourcePoint.x) / 2;
+      return `M${sourcePoint.x},${sourcePoint.y} 
+              L${midX},${sourcePoint.y} 
+              L${midX},${targetPoint.y} 
+              L${targetPoint.x},${targetPoint.y}`;
+    } else {
+      // Otherwise go vertical first
+      const midY = sourcePoint.y + (targetPoint.y - sourcePoint.y) / 2;
+      return `M${sourcePoint.x},${sourcePoint.y} 
+              L${sourcePoint.x},${midY} 
+              L${targetPoint.x},${midY} 
+              L${targetPoint.x},${targetPoint.y}`;
+    }
   });
   
-  // Update label positions
-  labelElements.attr('transform', d => {
+  // Update label positions with collision detection
+  labelElements.attr('transform', function(d) {
     const path = linkElements.filter(l => l === d).node();
     if (!path) return '';
     
@@ -1348,6 +1365,11 @@ function ticked() {
     
     // Position label at the midpoint of the path
     const midPoint = path.getPointAtLength(pathLength / 2);
+    
+    // Store the midpoint for collision detection
+    d.labelX = midPoint.x;
+    d.labelY = midPoint.y;
+    
     return `translate(${midPoint.x}, ${midPoint.y})`;
   });
   
@@ -1376,6 +1398,11 @@ function ticked() {
       .attr('width', maxX - minX + padding.x * 2)
       .attr('height', maxY - minY + padding.y * 2);
   });
+  
+  // Occasionally prevent label overlaps during simulation
+  if (Math.random() < 0.1) {
+    preventLabelOverlaps();
+  }
 }
 
 function dragStarted(event, d) {
@@ -1494,5 +1521,89 @@ function lineIntersection(x1, y1, x2, y2, x3, y3, x4, y4) {
   const y = y1 + ua * (y2 - y1);
   
   return { x, y };
+}
+
+// After positioning all labels, adjust positions to prevent overlaps
+function preventLabelOverlaps() {
+  const labels = labelElements.nodes();
+  const labelData = labelElements.data();
+  
+  // Create a quadtree for efficient collision detection
+  const quadtree = d3.quadtree()
+    .x(d => d.labelX)
+    .y(d => d.labelY)
+    .addAll(labelData);
+  
+  // For each label, check for overlaps and adjust position
+  labelElements.each(function(d, i) {
+    const labelGroup = d3.select(this);
+    const labelBg = labelGroup.select('.label-bg').node();
+    if (!labelBg) return;
+    
+    const bbox = labelBg.getBBox();
+    const padding = 10; // Extra space between labels
+    
+    // Define the bounds of this label
+    const x0 = d.labelX + bbox.x - padding;
+    const y0 = d.labelY + bbox.y - padding;
+    const x1 = d.labelX + bbox.x + bbox.width + padding;
+    const y1 = d.labelY + bbox.y + bbox.height + padding;
+    
+    // Find nearby labels that might overlap
+    quadtree.visit((node, x1q, y1q, x2q, y2q) => {
+      if (!node.length) {
+        do {
+          const d2 = node.data;
+          if (d2 && d2 !== d && labelOverlap(d, d2, bbox, padding)) {
+            // Adjust position to avoid overlap
+            adjustLabelPosition(d, d2);
+          }
+        } while (node = node.next);
+      }
+      return x1q > x1 || y1q > y1 || x2q < x0 || y2q < y0;
+    });
+    
+    // Update the transform with the potentially adjusted position
+    labelGroup.attr('transform', `translate(${d.labelX}, ${d.labelY})`);
+  });
+}
+
+// Check if two labels overlap
+function labelOverlap(d1, d2, bbox, padding) {
+  // Find the index of d2 in the data array
+  const d2Index = labelElements.data().indexOf(d2);
+  const labelGroup2 = d3.select(labelElements.nodes()[d2Index]);
+  const labelBg2 = labelGroup2.select('.label-bg').node();
+  if (!labelBg2) return false;
+  
+  const bbox2 = labelBg2.getBBox();
+  
+  // Check for rectangle overlap
+  return !(
+    d1.labelX + bbox.x + bbox.width + padding < d2.labelX + bbox2.x ||
+    d1.labelX + bbox.x > d2.labelX + bbox2.x + bbox2.width + padding ||
+    d1.labelY + bbox.y + bbox.height + padding < d2.labelY + bbox2.y ||
+    d1.labelY + bbox.y > d2.labelY + bbox2.y + bbox2.height + padding
+  );
+}
+
+// Adjust label position to avoid overlap
+function adjustLabelPosition(d1, d2) {
+  // Calculate vector between labels
+  const dx = d2.labelX - d1.labelX;
+  const dy = d2.labelY - d1.labelY;
+  const distance = Math.sqrt(dx * dx + dy * dy);
+  
+  if (distance < 1) {
+    // If labels are at the same position, move in a random direction
+    const angle = Math.random() * Math.PI * 2;
+    d1.labelX += Math.cos(angle) * 30;
+    d1.labelY += Math.sin(angle) * 30;
+  } else {
+    // Move away from the other label
+    const moveDistance = 30; // Distance to move
+    d1.labelX -= (dx / distance) * moveDistance;
+    d1.labelY -= (dy / distance) * moveDistance;
+  }
 }
 </script>

--- a/relations/index.html
+++ b/relations/index.html
@@ -265,7 +265,7 @@ It shows the generated graph and a legend, plus a button to go back to the searc
         <path fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
       </svg>
       <div id="loading-text" class="text-lg font-semibold text-navy mb-4">Loading graph...</div>
-      <div id="loading-nodes" class="text-gray-600 max-w-md mx-auto text-center max-h-[50vh] overflow-y-auto px-4">
+      <div id="loading-nodes" class="text-gray-600 max-w-md mx-auto text-center px-4 max-h-[80vh] overflow-y-auto">
         <!-- Node names will be added here -->
       </div>
     </div>
@@ -1858,7 +1858,6 @@ function displayNodesProgressively() {
       // Add text indicating this is the root node
       const relationSpan = document.createElement('div');
       relationSpan.className = 'text-sm opacity-80 ml-2';
-      relationSpan.textContent = '(root node)';
       rootDiv.appendChild(relationSpan);
       
       loadingNodesDiv.appendChild(rootDiv);
@@ -1866,7 +1865,7 @@ function displayNodesProgressively() {
       // Trigger fade in for root node
       setTimeout(() => {
         rootDiv.style.opacity = '1';
-      }, 100);
+      }, 150);
     }
     
     // Function to find relationship labels between root and a node

--- a/relations/index.html.backup
+++ b/relations/index.html.backup
@@ -247,7 +247,7 @@ It shows the generated graph and a legend, plus a button to go back to the searc
 
 <!-- Where the graph renders -->
 <div id="graph-container" class="border rounded flex items-center justify-center bg-white">
-  <svg id="graph" width="100%" height="100%" preserveAspectRatio="xMidYMid meet">
+  <svg id="graph" width="100%" height="100%">
     <defs>
       <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5"
         markerWidth="6" markerHeight="6" orient="auto-start-reverse">
@@ -1126,11 +1126,6 @@ function initializeD3Graph() {
   width = container.clientWidth;
   height = container.clientHeight;
   
-  // Set the SVG viewBox to cover the entire container
-  d3.select('#graph')
-    .attr('viewBox', `${-width/2} ${-height/2} ${width} ${height}`)
-    .attr('preserveAspectRatio', 'xMidYMid meet');
-  
   // Initialize zoom behavior
   zoom = d3.zoom()
     .scaleExtent([0.1, 2])
@@ -1143,7 +1138,7 @@ function initializeD3Graph() {
     .call(zoom)
     .on('dblclick.zoom', null); // Disable double-click zoom
     
-  // Center the graph with a moderate scale factor
+  // Reset zoom and pan with initial scale of 0.7 to show more of the graph
   resetZoom();
   
   // Show loading indicator
@@ -1151,10 +1146,10 @@ function initializeD3Graph() {
 }
 
 function resetZoom() {
-  // Center the graph with an appropriate scale
+  // Start with a zoomed-out view (scale 0.7) to show more of the graph
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(0, 0).scale(0.8)
+    d3.zoomIdentity.translate(width/2, height/2).scale(0.7)
   );
 }
 
@@ -1187,14 +1182,11 @@ function renderD3Graph(rootSubject, nodes, edges) {
   // Reset zoom and pan with centered graph
   d3.select('#graph').call(
     zoom.transform,
-    d3.zoomIdentity.translate(0, 0).scale(0.8) // Center at origin
+    d3.zoomIdentity.translate(width/2, height/2).scale(0.7) // Increased scale for better visibility
   );
   
-  // Create the graph content group with initial transform
+  // Create the graph content group with initial transform to center it
   const g = d3.select('#graph-content');
-  
-  // Explicitly set an initial transform on the graph content to center it
-  g.attr('transform', `translate(${width/2}, ${height/2})`);
   
   // Store the root subject for reference in other functions
   window.rootSubject = rootSubject;
@@ -1209,22 +1201,22 @@ function renderD3Graph(rootSubject, nodes, edges) {
     nodeMap.set(node.id, node);
   });
   
-  // Pre-position nodes in a structured layout
-  // Position root node in the center
+  // Pre-position nodes in a structured layout for better initial placement
+  // Position root node in the center of the canvas
   if (rootNode) {
-    rootNode.x = 0; // Position at origin (will be transformed to center)
-    rootNode.y = 0; // Position at origin (will be transformed to center)
-    rootNode.fx = 0; // Fix position at origin
-    rootNode.fy = 0; // Fix position at origin
+    rootNode.x = width / 2;
+    rootNode.y = height / 2; 
+    rootNode.fx = rootNode.x; // Fix position
+    rootNode.fy = rootNode.y;
   }
   
-  // Arrange non-root nodes in a circle around the root node at the origin
-  const radius = Math.min(width, height) * 0.25; // Use 25% of the smaller dimension for radius
+  // Arrange non-root nodes in a circular pattern around the root node
+  const radius = Math.min(width, height) * 0.35; // Radius for node distribution
   nonRootNodes.forEach((node, i) => {
     const angle = (i * 2 * Math.PI) / nonRootNodes.length;
-    node.x = radius * Math.cos(angle); // Position relative to origin
-    node.y = radius * Math.sin(angle); // Position relative to origin
-    // Don't fix these positions completely, allow force layout to adjust
+    node.x = width/2 + radius * Math.cos(angle);
+    node.y = height/2 + radius * Math.sin(angle);
+    // Don't fix these positions completely, but use them as starting points
   });
   
   // Preprocess edges to ensure all source and target nodes exist
@@ -1554,17 +1546,17 @@ function renderD3Graph(rootSubject, nodes, edges) {
           
           if (!sourceNode || !targetNode) {
             console.warn("Missing node in link distance calculation");
-            return forceParams.linkDistance * 1.5; // Moderately increased distance
+            return forceParams.linkDistance * 2.0; // Further increased distance
           }
           
           const sourceSize = Math.sqrt(getNodeWidth(sourceNode) * getNodeHeight(sourceNode));
           const targetSize = Math.sqrt(getNodeWidth(targetNode) * getNodeHeight(targetNode));
           
           // Base distance on node sizes plus padding - increased for better spacing
-          return (sourceSize + targetSize) / 2 + forceParams.linkDistance;
+          return (sourceSize + targetSize) / 2 + forceParams.linkDistance * 2.0; // Further increased distance multiplier
         } catch (error) {
           console.error("Error in link distance calculation:", error, d);
-          return forceParams.linkDistance * 1.5; // Moderately increased default distance
+          return forceParams.linkDistance * 2.0; // Further increased default distance
         }
       })
     )
@@ -1572,56 +1564,30 @@ function renderD3Graph(rootSubject, nodes, edges) {
       .strength(d => {
         // Stronger repulsion for structured layout
         const nodeSize = Math.sqrt(getNodeWidth(d) * getNodeHeight(d));
-        return forceParams.charge * (nodeSize / 200) * 1.5; // Moderately increased repulsion
+        return forceParams.charge * (nodeSize / 200) * 2.5; // Further increased repulsion
       })
       .distanceMin(300) // Further increased minimum distance
       .distanceMax(3000)) // Further increased maximum distance
-    .force('x', d3.forceX(0).strength(0.2)) // Center nodes horizontally at origin
-    .force('y', d3.forceY(0).strength(0.2)) // Center nodes vertically at origin
+    .force('x', d3.forceX(d => {
+      // Keep root node centered, let others spread horizontally
+      if (d.id === rootSubject) return width / 2;
+      return d.x; // Use pre-positioned x value
+    }).strength(d => d.id === rootSubject ? 1 : 0.1)) // Further reduced strength to allow more movement
+    .force('y', d3.forceY(d => {
+      // Keep root node at top, others in row below
+      if (d.id === rootSubject) return height * 0.2;
+      return height * 0.7;
+    }).strength(0.15)) // Further reduced strength to allow more movement
     .force('collision', d3.forceCollide().radius(d => {
       // Make collision radius based on node size plus padding
       const nodeWidth = getNodeWidth(d);
       const nodeHeight = getNodeHeight(d);
-      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 100; // Increased padding significantly
-    }).strength(0.8))
-    .alpha(0.8) // Higher alpha for more movement
-    .alphaDecay(0.01) // Slower decay for more time to find optimal positions
+      return Math.sqrt(nodeWidth * nodeHeight) / 1.2 + 120; // Further increased padding significantly
+    }).strength(1))
+    .alpha(0.9) // Higher alpha for more movement
+    .alphaDecay(0.005) // Slower decay for more time to find optimal positions
     .velocityDecay(0.4)
-    .on('tick', ticked)
-    .on('end', () => {
-      // When the simulation ends, center the graph based on actual content bounds
-      centerGraph();
-    });
-}
-
-// Function to center the graph based on its actual rendered bounds
-function centerGraph() {
-  try {
-    // Get the bounding box of the graph content
-    const bbox = document.getElementById('graph-content').getBBox();
-    
-    // Calculate the center of the graph content
-    const graphCenterX = bbox.x + bbox.width / 2;
-    const graphCenterY = bbox.y + bbox.height / 2;
-    
-    // Calculate the translation needed to center the graph
-    const translateX = width / 2 - graphCenterX;
-    const translateY = height / 2 - graphCenterY;
-    
-    // Update the zoom transform to center the graph
-    d3.select('#graph').call(
-      zoom.transform,
-      d3.zoomIdentity.translate(translateX, translateY).scale(0.8)
-    );
-    
-    console.log('Graph centered based on actual bounds:', { 
-      bbox, 
-      graphCenter: { x: graphCenterX, y: graphCenterY },
-      translation: { x: translateX, y: translateY }
-    });
-  } catch (error) {
-    console.error('Error centering graph:', error);
-  }
+    .on('tick', ticked);
 }
 
 // Update the ticked function to properly position nodes, links, and labels
@@ -1629,11 +1595,9 @@ function ticked() {
   try {
     // Update node positions
     nodeElements.attr('transform', d => {
-      // Constrain to bounds relative to origin
-      const halfWidth = width / 2;
-      const halfHeight = height / 2;
-      d.x = Math.max(-halfWidth + 50, Math.min(halfWidth - 50, d.x));
-      d.y = Math.max(-halfHeight + 50, Math.min(halfHeight - 50, d.y));
+      // Constrain to bounds
+      d.x = Math.max(50, Math.min(width - 50, d.x));
+      d.y = Math.max(50, Math.min(height - 50, d.y));
       return `translate(${d.x - getNodeWidth(d) / 2}, ${d.y - getNodeHeight(d) / 2})`;
     });
     


### PR DESCRIPTION
It's not perfect but it's hopefully a step in the right direction.

## Switches from Graphviz to d3

### Before

<img width="1213" alt="image" src="https://github.com/user-attachments/assets/be383f9d-db83-4622-98e4-717b4ab9a98c" />

### After

<img width="1195" alt="image" src="https://github.com/user-attachments/assets/893153d5-f906-4ddb-b2c5-14456b5a7f70" />

## Adds loading state

<img width="568" alt="image" src="https://github.com/user-attachments/assets/e9a22221-29ee-4272-9dbd-573b583ffd29" />

## Highlights a connection when hovered

<img width="1139" alt="image" src="https://github.com/user-attachments/assets/1c48a634-fb19-49fa-908d-bb0ed45822d5" />

## Adds zoom controls to match `/expose`

<img width="663" alt="image" src="https://github.com/user-attachments/assets/cec225a4-0127-417e-a99c-b5079e818c00" />

---

## Things I'm not happy with yet

- Initial positioning of canvas is sometimes wonky (too far down the page)
- Routes of lines
- On smaller viewports, nodes are prone to overlapping, especially on mobile
- Had trouble adding search to the graph (to match `/expose`)